### PR TITLE
Add written English plural support

### DIFF
--- a/lib/Intlc/ICU.hs
+++ b/lib/Intlc/ICU.hs
@@ -23,12 +23,12 @@ data Token
 data Arg = Arg Text Type
   deriving (Show, Eq)
 
+-- We diverge from icu4j by not necessarily requiring wildcard cases.
 data Type
   = String
   | Number
   | Date DateFmt
-  | Plural (NonEmpty PluralCase) PluralWildcard
-  -- We diverge from icu4j by not requiring a wildcard case.
+  | Plural Plural
   | Select (NonEmpty SelectCase) (Maybe SelectWildcard)
   | Callback Stream
   deriving (Show, Eq)
@@ -40,16 +40,45 @@ data DateFmt
   | Full
   deriving (Show, Eq)
 
+-- | Plurals can be split into four usages:
+--
+--   1. Literal number cases without a wildcard.
+--   2. Literal number cases with a wildcard.
+--   3. Rule cases with a wildcard.
+--   3. Mixed cases with a wildcard.
+--
+-- Per the aforementioned usages, any plural with at least one rule case must
+-- have a wildcard, and plurals without any rule cases can optionally supply
+-- a wildcard.
+data Plural
+  = LitPlural (NonEmpty (PluralCase PluralExact)) (Maybe PluralWildcard)
+  | RulePlural (NonEmpty (PluralCase PluralRule)) PluralWildcard
+  | MixedPlural (NonEmpty (PluralCase PluralExact)) (NonEmpty (PluralCase PluralRule)) PluralWildcard
+  deriving (Show, Eq)
+
+data PluralCase a = PluralCase a Stream
+  deriving (Show, Eq)
+
+-- `Text` here is our count. It's represented as a string so that we can dump
+-- it back out without thinking about converting numeric types across
+-- languages.
+newtype PluralExact = PluralExact Text
+  deriving (Show, Eq)
+
+-- "Other" is implied in the wildcard.
+data PluralRule
+  = Zero
+  | One
+  | Two
+  | Few
+  | Many
+  deriving (Show, Eq)
+
+newtype PluralWildcard = PluralWildcard Stream
+  deriving (Show, Eq)
+
 data SelectCase = SelectCase Text Stream
   deriving (Show, Eq)
 
 newtype SelectWildcard = SelectWildcard Stream
-  deriving (Show, Eq)
-
--- `Text` here is our count. It's represented as a string so that we can dump
--- it back out without thinking about converting numeric types across languages.
-data PluralCase = PluralCase Text Stream
-  deriving (Show, Eq)
-
-newtype PluralWildcard = PluralWildcard Stream
   deriving (Show, Eq)

--- a/test/Intlc/CompilerSpec.hs
+++ b/test/Intlc/CompilerSpec.hs
@@ -15,4 +15,4 @@ spec = describe "compiler" $ do
       numErrs [Arg "x" Number, Arg "y" String, Arg "x" String, Arg "z" Number, Arg "z" String] `shouldBe` 2
 
     it "considers the underlying type when deducing incompatibility" $ do
-      numErrs [Arg "x" Number, Arg "x" (Plural (pure $ PluralCase "42" []) (PluralWildcard []))] `shouldBe` 0
+      numErrs [Arg "x" Number, Arg "x" (Plural (LitPlural (pure $ PluralCase (PluralExact "42") []) Nothing))] `shouldBe` 0

--- a/test/Intlc/EndToEndSpec.hs
+++ b/test/Intlc/EndToEndSpec.hs
@@ -26,6 +26,10 @@ spec = describe "end-to-end" $ do
       =*= "export const prop: (x: { age: number; name: string }) => string = x => `Age: ${(() => { switch (x.age) { case 0: return `newborn called ${x.name}`; case 42: return `magical`; default: return `boring ${x.age}`; } })()}`"
     [r|{ "prop": { "message": "Age: {age, plural, =0 {newborn called {name}} =42 {magical} other {boring #}}", "backend": "tsx" } }|]
       =*= "export const prop: (x: { age: number; name: string }) => ReactElement = x => <>Age: {(() => { switch (x.age) { case 0: return <>newborn called {x.name}</>; case 42: return <>magical</>; default: return <>boring {x.age}</>; } })()}</>"
+    [r|{ "f": { "message": "{n, plural, =0 {x} =42 {y}}", "backend": "ts" } }|]
+      =*= "export const f: (x: { n: 0 | 42 }) => string = x => `${(() => { switch (x.n) { case 0: return `x`; case 42: return `y`; } })()}`"
+    [r|{ "f": { "message": "{n, plural, =0 {zero} many {many} other {#}}", "backend": "ts" } }|]
+      =*= "export const f: (x: { n: number }) => string = x => `${(() => { switch (x.n) { case 0: return `zero`; default: { switch (new Intl.PluralRules('en-US').select(x.n)) { case 'many': return `many`; default: return `${x.n}`; } } } })()}`"
 
   it "compiles select" $ do
     [r|{ "f": { "message": "{x, select, a {hi} b {yo}}", "backend": "ts" } }|]


### PR DESCRIPTION
Closes #7.

As-is at least the "few" and "many" cases are wrong. See:

- https://cldr.unicode.org/index/cldr-spec/plural-rules
- https://formatjs.io/docs/core-concepts/icu-syntax/#plural-format

Before I proceed, how will this eventually be compiled? Will this be offloaded to a web API?