### PR TITLE
Fix: React import casing

### DIFF
--- a/lib/Intlc/Compiler/Backend/TypeScript.hs
+++ b/lib/Intlc/Compiler/Backend/TypeScript.hs
@@ -25,7 +25,7 @@ compileTypeof :: InterpStrat -> ICU.Message -> Text
 compileTypeof x = let o = fromStrat x in flip runReader o . typeof . fromMsg o
 
 reactImport :: Text 
-reactImport = "import React, { ReactElement } from 'React'"
+reactImport = "import React, { ReactElement } from 'react'"
 
 fromStrat :: InterpStrat -> Out
 fromStrat TemplateLit = TUniOut TStr

--- a/test/Intlc/EndToEndSpec.hs
+++ b/test/Intlc/EndToEndSpec.hs
@@ -13,7 +13,7 @@ x =*= y = f x `shouldBe` Right y
   where f = compileDataset (Locale "en-US") <=< first (pure . show) . parseDataset
 
 withReactImport :: Text -> Text
-withReactImport = ("import React, { ReactElement } from 'React'\n" <>)
+withReactImport = ("import React, { ReactElement } from 'react'\n" <>)
 
 spec :: Spec
 spec = describe "end-to-end" $ do


### PR DESCRIPTION
Locally it works because I think MacOs uses a case insensitive partition by default 🤦‍♂️. It fails on the web ci