### PR TITLE
Add golden/snapshot testing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 /dist-newstyle/
+/.golden/**/*/actual*
 

--- a/.golden/e2e/example/golden.ts
+++ b/.golden/e2e/example/golden.ts
@@ -1,0 +1,3 @@
+import React, { ReactElement } from 'react'
+export const greeting: (x: { bold: (x: string) => string; name: string; age: number }) => string = x => `Hello ${x.bold(`${x.name}`)}, ${new Intl.NumberFormat('en-US').format(x.age)}!`
+export const title: () => string = () => 'Unsplash'

--- a/intlc.cabal
+++ b/intlc.cabal
@@ -62,7 +62,9 @@ test-suite test-intlc
   type:                     exitcode-stdio-1.0
   build-depends:
       intlc
+    , filepath              ^>=1.4
     , hspec                 ^>=2.7
+    , hspec-golden          ^>=0.2
     , hspec-megaparsec      ^>=2.2
     , megaparsec            ^>=9.0
     , raw-strings-qq        ^>=1.1

--- a/test/Intlc/EndToEndSpec.hs
+++ b/test/Intlc/EndToEndSpec.hs
@@ -1,16 +1,32 @@
 module Intlc.EndToEndSpec (spec) where
 
 import           Data.ByteString.Lazy (ByteString)
+import qualified Data.Text            as T
 import           Intlc.Compiler       (compileDataset)
 import           Intlc.Core           (Locale (Locale))
 import           Intlc.Parser         (parseDataset)
 import           Prelude              hiding (ByteString)
+import           System.FilePath      ((<.>), (</>))
 import           Test.Hspec
+import           Test.Hspec.Golden    (Golden (..), defaultGolden)
 import           Text.RawString.QQ    (r)
 
+parseAndCompileDataset :: ByteString -> Either (NonEmpty Text) Text
+parseAndCompileDataset = compileDataset (Locale "en-US") <=< first (pure . show) . parseDataset
+
+golden :: String -> ByteString -> Golden String
+golden name in' = baseCfg
+  { goldenFile = goldenFile baseCfg <.> "ts"
+  , actualFile = actualFile baseCfg <&> (<.> "ts")
+  }
+  where baseCfg = defaultGolden fileName out
+        fileName = "e2e" </> name
+        out = T.unpack . fromErrs . parseAndCompileDataset $ in'
+        fromErrs (Right x) = x
+        fromErrs (Left es) = T.intercalate "\n" . toList $ es
+
 (=*=) :: ByteString -> Text -> IO ()
-x =*= y = f x `shouldBe` Right y
-  where f = compileDataset (Locale "en-US") <=< first (pure . show) . parseDataset
+x =*= y = parseAndCompileDataset x `shouldBe` Right y
 
 withReactImport :: Text -> Text
 withReactImport = ("import React, { ReactElement } from 'react'\n" <>)
@@ -18,8 +34,7 @@ withReactImport = ("import React, { ReactElement } from 'react'\n" <>)
 spec :: Spec
 spec = describe "end-to-end" $ do
   it "example message" $ do
-    [r|{ "title": { "message": "Unsplash" }, "greeting": { "message": "Hello <bold>{name}</bold>, {age, number}!", "backend": "ts" } }|]
-      =*= withReactImport "export const greeting: (x: { bold: (x: string) => string; name: string; age: number }) => string = x => `Hello ${x.bold(`${x.name}`)}, ${new Intl.NumberFormat('en-US').format(x.age)}!`\nexport const title: () => string = () => 'Unsplash'"
+    golden "example" [r|{ "title": { "message": "Unsplash" }, "greeting": { "message": "Hello <bold>{name}</bold>, {age, number}!", "backend": "ts" } }|]
 
   it "parses and discards descriptions" $ do
     [r|{ "brand": { "message": "Unsplash", "description": "The company name" } }|]


### PR DESCRIPTION
Closes #35. Thanks @Magellol for your initial outlay!

This PR adds golden/snapshot testing with an example test migration included. There's no longer any need to write the expected output code, merely verify prior to committing that it looks correct.

It outputs `.ts` files, so we get syntax highlighting and per @Magellol's suggestion in the linked issue we could pursue typechecking these perhaps as a CI step. If a test fails the output will be the printed error(s).

I believe the gitignore pattern is safe provided we always include an `actual` prefix in our `actualFile` outputs.