### PR TITLE
Strict braces

### DIFF
--- a/test/Intlc/ParserSpec.hs
+++ b/test/Intlc/ParserSpec.hs
@@ -14,17 +14,6 @@ parse' = flip parse "test"
 spec :: Spec
 spec = describe "parser" $ do
   describe "message" $ do
-    it "tolerates unclosed braces" $ do
-      parse' msg "a {b} c { d" `shouldParse`
-        Dynamic (Plaintext "a " :| [Interpolation (Arg "b" String), Plaintext " c { d"])
-
-    it "tolerates empty braces" $ do
-      parse' msg "a {b} c {} d {e, number}" `shouldParse`
-        Dynamic (Plaintext "a " :| [Interpolation (Arg "b" String), Plaintext " c {} d ", Interpolation (Arg "e" Number)])
-
-    it "tolerates interpolations with a bad type" $ do
-      parse' msg "{n, bool}" `shouldParse` Static "{n, bool}"
-
     it "does not tolerate empty tags" $ do
       parse' msg `shouldFailOn` "a <> b"
 
@@ -64,6 +53,10 @@ spec = describe "parser" $ do
     it "only accepts alphanumeric identifiers" $ do
       parse' interp "{XyZ}" `shouldParse` Arg "XyZ" String
       parse' interp `shouldFailOn` "{x y}"
+
+    it "disallows bad types" $ do
+      parse' msg `shouldFailOn` "{n, bool}"
+      parse' msg `shouldFailOn` "{n, int, one {x} other {y}}"
 
     describe "date" $ do
       it "disallows bad formats" $ do

--- a/test/Intlc/ParserSpec.hs
+++ b/test/Intlc/ParserSpec.hs
@@ -14,6 +14,15 @@ parse' = flip parse "test"
 spec :: Spec
 spec = describe "parser" $ do
   describe "message" $ do
+    it "does not tolerate unclosed braces" $ do
+      parse' msg `shouldFailOn` "a { b"
+
+    it "does not tolerate interpolations with a bad type" $ do
+      parse' msg `shouldFailOn` "a {n, bool} b"
+
+    it "does not tolerate empty braces" $ do
+      parse' msg `shouldFailOn` "a {} b"
+
     it "does not tolerate empty tags" $ do
       parse' msg `shouldFailOn` "a <> b"
 

--- a/test/Intlc/ParserSpec.hs
+++ b/test/Intlc/ParserSpec.hs
@@ -63,9 +63,7 @@ spec = describe "parser" $ do
 
     it "only accepts alphanumeric identifiers" $ do
       parse' interp "{XyZ}" `shouldParse` Arg "XyZ" String
-      parse' interp "<XyZ></XyZ>" `shouldParse` Arg "XyZ" (Callback [])
       parse' interp `shouldFailOn` "{x y}"
-      parse' interp `shouldFailOn` "<x y></x y>"
 
     describe "date" $ do
       it "disallows bad formats" $ do
@@ -91,6 +89,10 @@ spec = describe "parser" $ do
 
       parse' callback "<hello> there" `shouldFailWith` e 1 (NoClosingCallbackTag "hello")
       parse' callback "<hello> </there>" `shouldFailWith` e 10 (BadClosingCallbackTag "hello" "there")
+
+    it "only accepts alphanumeric identifiers" $ do
+      parse' callback "<XyZ></XyZ>" `shouldParse` Arg "XyZ" (Callback [])
+      parse' callback `shouldFailOn` "<x y></x y>"
 
   describe "plural" $ do
     it "disallows wildcard not at the end" $ do


### PR DESCRIPTION
Closes #24.

Per the tests, parsing is now much stricter around interpolations; the likes of `{unclosed` and `{x, badtype}` are no longer parseable. The rationale is that the translator can always incorporate braces by escaping, and this strictness makes it a lot easier to spot faulty messages.

Is there any reason we can't or shouldn't rely upon escaping like this for access to braces?