### PR TITLE
Validate keys contain only valid chars

### DIFF
--- a/lib/Intlc/Parser.hs
+++ b/lib/Intlc/Parser.hs
@@ -7,6 +7,7 @@ module Intlc.Parser where
 import qualified Control.Applicative.Combinators.NonEmpty as NE
 import           Data.Aeson                               (decode)
 import           Data.ByteString.Lazy                     (ByteString)
+import           Data.Char                                (isAlpha)
 import qualified Data.Map                                 as M
 import qualified Data.Text                                as T
 import           Data.Void                                ()
@@ -21,6 +22,7 @@ import           Text.Megaparsec.Error.Builder
 
 data ParseFailure
   = FailedJsonParse
+  | InvalidKeys (NonEmpty Text)
   | FailedMessageParse ParseErr
   deriving (Show, Eq)
 
@@ -35,12 +37,19 @@ instance ShowErrorComponent MessageParseErr where
 
 printErr :: ParseFailure -> String
 printErr FailedJsonParse        = "Failed to parse JSON"
+printErr (InvalidKeys ks)       = T.unpack $ "Invalid keys: " <> T.intercalate ", " (toList ks)
 printErr (FailedMessageParse e) = errorBundlePretty e
 
 parseDataset :: ByteString -> Either ParseFailure (Dataset Translation)
-parseDataset = parse' <=< decode'
+parseDataset = parse' <=< validateKeys <=< decode'
   where decode' = maybeToRight FailedJsonParse . decode
         parse' = M.traverseWithKey ((first FailedMessageParse .) . parseTranslationFor)
+
+validateKeys :: Dataset a -> Either ParseFailure (Dataset a)
+validateKeys xs = toEither . nonEmpty . filter (not . isValidKey) . M.keys $ xs
+  where toEither Nothing   = Right xs
+        toEither (Just ks) = Left . InvalidKeys $ ks
+        isValidKey = T.all (liftA2 (||) isAlpha (== '_'))
 
 parseTranslationFor :: Text -> UnparsedTranslation -> Either ParseErr Translation
 parseTranslationFor name (UnparsedTranslation umsg be) =

--- a/test/Intlc/EndToEndSpec.hs
+++ b/test/Intlc/EndToEndSpec.hs
@@ -4,7 +4,7 @@ import           Data.ByteString.Lazy (ByteString)
 import qualified Data.Text            as T
 import           Intlc.Compiler       (compileDataset)
 import           Intlc.Core           (Locale (Locale))
-import           Intlc.Parser         (parseDataset)
+import           Intlc.Parser         (ParseFailure (..), parseDataset)
 import           Prelude              hiding (ByteString)
 import           System.FilePath      ((<.>), (</>))
 import           Test.Hspec
@@ -35,6 +35,10 @@ spec :: Spec
 spec = describe "end-to-end" $ do
   it "example message" $ do
     golden "example" [r|{ "title": { "message": "Unsplash" }, "greeting": { "message": "Hello <bold>{name}</bold>, {age, number}!", "backend": "ts" } }|]
+
+  it "validates that keys are alphanumeric" $ do
+    parseDataset [r|{ "x bad key": { "message": "foo" }, "good_Key": { "message": "bar" }, "y-bad-key": { "message": "baz" }, "z_bad_key123": { "message": "biz" } }|] `shouldBe`
+      Left (InvalidKeys $ "x bad key" :| ["y-bad-key", "z_bad_key123"])
 
   it "parses and discards descriptions" $ do
     [r|{ "brand": { "message": "Unsplash", "description": "The company name" } }|]


### PR DESCRIPTION
Closes #14.

This PR performs cheap validation against message keys to ensure all characters are either alphabetical or underscores.

A better long-term solution would probably be to have per-compiler massaging of keys, and error handling to handle conflicts in that scenario, but for now with only TS(X) backends this does the job.

Numbers aren't permitted as they aren't valid as the first character of a JS identifier, and I want this code to be as simple as possible at this stage. `$` isn't permitted because I don't want to encourage JS looking like PHP. In all seriousness, that could be fixed with the above per-compiler approach, but I think this is reasonable as a short-term solution to ensure valid output.