### PR TITLE
Fix nested plural hash

### DIFF
--- a/lib/Intlc/Parser.hs
+++ b/lib/Intlc/Parser.hs
@@ -63,6 +63,21 @@ data ParserState = ParserState
 initialState :: ParserState
 initialState = ParserState mempty
 
+peekPluralArgName :: ParserState -> Maybe Text
+peekPluralArgName = listToMaybe . pluralArgNameStack
+
+pushPluralArgName :: Text -> ParserState -> ParserState
+pushPluralArgName n x = x { pluralArgNameStack = n : pluralArgNameStack x }
+
+popPluralArgName :: ParserState -> (Maybe Text, ParserState)
+popPluralArgName x =
+  case pluralArgNameStack x of
+    []     -> (Nothing, x)
+    (y:ys) -> (Just y, x { pluralArgNameStack = ys })
+
+popPluralArgName_ :: ParserState -> ParserState
+popPluralArgName_ = snd . popPluralArgName
+
 type Parser = ParsecT MessageParseErr Text (State ParserState)
 
 ident :: Parser Text
@@ -75,10 +90,18 @@ msg = f . mergePlaintext <$> manyTill token eof
         f (x:xs)        = Dynamic (x :| xs)
 
 token :: Parser Token
-token = choice
-  [ Interpolation <$> (interp <|> callback)
-  , Plaintext     <$> (try escaped <|> plaintext)
-  ]
+token = do
+  marg <- gets peekPluralArgName
+  choice
+    [ Interpolation <$> (interp <|> callback)
+    -- Plural cases support interpolating the number/argument in context with
+    -- `#`. When there's no such context, fail the parse in effect treating it
+    -- as plaintext.
+    , case marg of
+        Just n  -> Interpolation (Arg n Number) <$ string "#"
+        Nothing -> empty
+    , Plaintext <$> (try escaped <|> plaintext)
+    ]
 
 plaintext :: Parser Text
 plaintext = T.singleton <$> L.charLiteral
@@ -124,10 +147,13 @@ interp = do
           [ Number <$ string "number"
           , Date <$> (string "date" *> sep *> dateTimeFmt)
           , Time <$> (string "time" *> sep *> dateTimeFmt)
-          , Plural <$> (string "plural" *> sep *> cardinalPluralCases n)
-          , Plural <$> (string "selectordinal" *> sep *> ordinalPluralCases n)
+          , Plural <$> withPluralCtx n (string "plural" *> sep *> cardinalPluralCases)
+          , Plural <$> withPluralCtx n (string "selectordinal" *> sep *> ordinalPluralCases)
           , uncurry Select <$> (string "select" *> sep *> selectCases)
           ]
+        withPluralCtx n p = pushPluralCtx n *> p <* popPluralCtx
+        pushPluralCtx = modify . pushPluralArgName
+        popPluralCtx = modify popPluralArgName_
 
 dateTimeFmt :: Parser DateTimeFmt
 dateTimeFmt = choice
@@ -145,25 +171,25 @@ selectCases = (,) <$> cases <*> optional wildcard
         body = mergePlaintext <$> (string "{" *> manyTill token (string "}"))
         wildcardName = "other"
 
-cardinalPluralCases :: Text -> Parser Plural
-cardinalPluralCases n = fmap Cardinal . tryClassify =<< p
+cardinalPluralCases :: Parser Plural
+cardinalPluralCases = fmap Cardinal . tryClassify =<< p
     where tryClassify = maybe empty pure . uncurry classifyCardinal
-          p = (,) <$> disorderedPluralCases n <*> optional (pluralWildcard n)
+          p = (,) <$> disorderedPluralCases <*> optional pluralWildcard
 
-ordinalPluralCases :: Text -> Parser Plural
-ordinalPluralCases n = fmap Ordinal . tryClassify =<< p
+ordinalPluralCases :: Parser Plural
+ordinalPluralCases = fmap Ordinal . tryClassify =<< p
     where tryClassify = maybe empty pure . uncurry classifyOrdinal
-          p = (,) <$> disorderedPluralCases n <*> pluralWildcard n
+          p = (,) <$> disorderedPluralCases <*> pluralWildcard
 
 -- Need to lift parsed plural cases into this type to make the list homogeneous.
 data ParsedPluralCase
   = ParsedExact (PluralCase PluralExact)
   | ParsedRule (PluralCase PluralRule)
 
-disorderedPluralCases :: Text -> Parser (NonEmpty ParsedPluralCase)
-disorderedPluralCases n = flip NE.sepEndBy1 hspace1 $ choice
-  [ (ParsedExact .) . PluralCase <$> pluralExact <* hspace1 <*> pluralBody n
-  , (ParsedRule .)  . PluralCase <$> pluralRule  <* hspace1 <*> pluralBody n
+disorderedPluralCases :: Parser (NonEmpty ParsedPluralCase)
+disorderedPluralCases = flip NE.sepEndBy1 hspace1 $ choice
+  [ (ParsedExact .) . PluralCase <$> pluralExact <* hspace1 <*> pluralBody
+  , (ParsedRule .)  . PluralCase <$> pluralRule  <* hspace1 <*> pluralBody
   ]
 
 pluralExact :: Parser PluralExact
@@ -178,13 +204,11 @@ pluralRule = choice
   , Many <$ string "many"
   ]
 
-pluralWildcard :: Text -> Parser PluralWildcard
-pluralWildcard n = PluralWildcard <$> (string "other" *> hspace1 *> pluralBody n)
+pluralWildcard :: Parser PluralWildcard
+pluralWildcard = PluralWildcard <$> (string "other" *> hspace1 *> pluralBody)
 
-pluralBody :: Text -> Parser Stream
-pluralBody n = mergePlaintext <$> (string "{" *> manyTill pluralToken (string "}"))
-  -- Plural cases support interpolating the number/argument in context with `#`.
-  where pluralToken = Interpolation (Arg n Number) <$ string "#" <|> token
+pluralBody :: Parser Stream
+pluralBody = mergePlaintext <$> (string "{" *> manyTill token (string "}"))
 
 -- | To simplify parsing cases we validate after-the-fact here. This achieves
 -- two purposes. Firstly it enables us to fail the parse if the cases are not

--- a/test/Intlc/ParserSpec.hs
+++ b/test/Intlc/ParserSpec.hs
@@ -11,38 +11,38 @@ import           Text.Megaparsec.Error (ErrorFancy (ErrorCustom))
 parseWith :: ParserState -> Parser a -> Text -> Either (ParseErrorBundle Text MessageParseErr) a
 parseWith s p x = evalState (runParserT p "test" x) s
 
-parse' :: Parser a -> Text -> Either (ParseErrorBundle Text MessageParseErr) a
-parse' = parseWith initialState
+parse :: Parser a -> Text -> Either (ParseErrorBundle Text MessageParseErr) a
+parse = parseWith initialState
 
 spec :: Spec
 spec = describe "parser" $ do
   describe "message" $ do
     it "does not tolerate unclosed braces" $ do
-      parse' msg `shouldFailOn` "a { b"
+      parse msg `shouldFailOn` "a { b"
 
     it "does not tolerate interpolations with a bad type" $ do
-      parse' msg `shouldFailOn` "a {n, bool} b"
+      parse msg `shouldFailOn` "a {n, bool} b"
 
     it "does not tolerate empty braces" $ do
-      parse' msg `shouldFailOn` "a {} b"
+      parse msg `shouldFailOn` "a {} b"
 
     it "does not tolerate empty tags" $ do
-      parse' msg `shouldFailOn` "a <> b"
+      parse msg `shouldFailOn` "a <> b"
 
     describe "plural hash" $ do
       it "parses as plaintext outside of plurals" $ do
-        parse' msg "#" `shouldParse` Static "#"
+        parse msg "#" `shouldParse` Static "#"
 
       it "parses as arg inside shallow plural" $ do
         let n = pure . Interpolation $ Arg "n" Number
-        parse' msg "{n, plural, one {#} other {#}}" `shouldParse`
+        parse msg "{n, plural, one {#} other {#}}" `shouldParse`
           (Dynamic . pure . Interpolation . Arg "n" . Plural . Cardinal $
             RulePlural (pure $ PluralCase One n) (PluralWildcard n))
 
       it "parses as nearest arg inside deep plural" $ do
         let n = pure . Interpolation $ Arg "n" Number
         let i = pure . Interpolation $ Arg "i" Number
-        parse' msg "{n, plural, one {{i, plural, one {#} other {#}}} other {#}}" `shouldParse`
+        parse msg "{n, plural, one {{i, plural, one {#} other {#}}} other {#}}" `shouldParse`
           (Dynamic . pure . Interpolation . Arg "n" . Plural . Cardinal $
             RulePlural (pure $ PluralCase One (
               pure . Interpolation . Arg "i" . Plural . Cardinal $
@@ -51,7 +51,7 @@ spec = describe "parser" $ do
 
       it "parses as arg nested inside other interpolation" $ do
         let n = pure . Interpolation $ Arg "n" Number
-        parse' msg "{n, plural, one {<f>#</f>} other {#}}" `shouldParse`
+        parse msg "{n, plural, one {<f>#</f>} other {#}}" `shouldParse`
           (Dynamic . pure . Interpolation . Arg "n" . Plural . Cardinal $
             RulePlural (pure $ PluralCase One (
               pure . Interpolation . Arg "f" . Callback $ n
@@ -59,91 +59,91 @@ spec = describe "parser" $ do
 
     describe "escaping" $ do
       it "escapes non-empty contents between single quotes" $ do
-        parse' msg "These are not interpolations: '{word1} {word2}'" `shouldParse`
+        parse msg "These are not interpolations: '{word1} {word2}'" `shouldParse`
           Static "These are not interpolations: {word1} {word2}"
-        parse' msg "'<notATag>hello</notATag>'" `shouldParse`
+        parse msg "'<notATag>hello</notATag>'" `shouldParse`
           Static "<notATag>hello</notATag>"
-        parse' msg "a {b} '{c}' {d} e" `shouldParse`
+        parse msg "a {b} '{c}' {d} e" `shouldParse`
           Dynamic (Plaintext "a " :| [Interpolation (Arg "b" String), Plaintext " {c} ", Interpolation (Arg "d" String), Plaintext " e"])
-        parse' msg "'<f>'" `shouldParse` Static "<f>"
-        parse' msg "'<f>x</f>'" `shouldParse` Static "<f>x</f>"
-        parse' msg "'<f>x</g>'" `shouldParse` Static "<f>x</g>"
+        parse msg "'<f>'" `shouldParse` Static "<f>"
+        parse msg "'<f>x</f>'" `shouldParse` Static "<f>x</f>"
+        parse msg "'<f>x</g>'" `shouldParse` Static "<f>x</g>"
 
       it "escapes next syntax character following one unclosed single quote" $ do
-        parse' msg "This is not an interpolation: '{word}" `shouldParse` Static "This is not an interpolation: {word}"
-        parse' msg "'<notATag>" `shouldParse` Static "<notATag>"
-        parse' msg "a {b} '{c} {d} e" `shouldParse`
+        parse msg "This is not an interpolation: '{word}" `shouldParse` Static "This is not an interpolation: {word}"
+        parse msg "'<notATag>" `shouldParse` Static "<notATag>"
+        parse msg "a {b} '{c} {d} e" `shouldParse`
           Dynamic (Plaintext "a " :| [Interpolation (Arg "b" String), Plaintext " {c} ", Interpolation (Arg "d" String), Plaintext " e"])
-        parse' msg "a {b} 'c {d} e" `shouldParse`
+        parse msg "a {b} 'c {d} e" `shouldParse`
           Dynamic (Plaintext "a " :| [Interpolation (Arg "b" String), Plaintext " 'c ", Interpolation (Arg "d" String), Plaintext " e"])
 
       it "escapes two single quotes as one single quote" $ do
-        parse' msg "This '{isn''t}' obvious." `shouldParse` Static "This {isn't} obvious."
-        parse' msg "a {b} ''{c}'' {d} e" `shouldParse`
+        parse msg "This '{isn''t}' obvious." `shouldParse` Static "This {isn't} obvious."
+        parse msg "a {b} ''{c}'' {d} e" `shouldParse`
           Dynamic (Plaintext "a " :| [Interpolation (Arg "b" String), Plaintext " '", Interpolation (Arg "c" String), Plaintext "' ", Interpolation (Arg "d" String), Plaintext " e"])
 
       it "ignores one single quote not immediately preceding a syntax character" $ do
-        parse' msg "'" `shouldParse` Static "'"
-        parse' msg "x'y" `shouldParse` Static "x'y"
+        parse msg "'" `shouldParse` Static "'"
+        parse msg "x'y" `shouldParse` Static "x'y"
 
   describe "interpolation" $ do
     it "interpolates appropriately" $ do
-      parse' interp "{x}" `shouldParse` Arg "x" String
+      parse interp "{x}" `shouldParse` Arg "x" String
 
     it "only accepts alphanumeric identifiers" $ do
-      parse' interp "{XyZ}" `shouldParse` Arg "XyZ" String
-      parse' interp `shouldFailOn` "{x y}"
+      parse interp "{XyZ}" `shouldParse` Arg "XyZ" String
+      parse interp `shouldFailOn` "{x y}"
 
     it "disallows bad types" $ do
-      parse' msg `shouldFailOn` "{n, bool}"
-      parse' msg `shouldFailOn` "{n, int, one {x} other {y}}"
+      parse msg `shouldFailOn` "{n, bool}"
+      parse msg `shouldFailOn` "{n, int, one {x} other {y}}"
 
     describe "date" $ do
       it "disallows bad formats" $ do
-        parse' interp "{x, date, short}" `shouldParse` Arg "x" (Date Short)
-        parse' interp `shouldFailOn` "{x, date, miniature}"
+        parse interp "{x, date, short}" `shouldParse` Arg "x" (Date Short)
+        parse interp `shouldFailOn` "{x, date, miniature}"
 
     describe "time" $ do
       it "disallows bad formats" $ do
-        parse' interp "{x, time, short}" `shouldParse` Arg "x" (Time Short)
-        parse' interp `shouldFailOn` "{x, time, miniature}"
+        parse interp "{x, time, short}" `shouldParse` Arg "x" (Time Short)
+        parse interp `shouldFailOn` "{x, time, miniature}"
 
   describe "callback" $ do
     it "parses nested" $ do
-      parse' callback "<f><g>x{y}z</g></f>" `shouldParse`
+      parse callback "<f><g>x{y}z</g></f>" `shouldParse`
         Arg "f" (Callback [Interpolation $ Arg "g" (Callback [Plaintext "x", Interpolation (Arg "y" String), Plaintext "z"])])
 
     it "validates closing tag name" $ do
-      parse' callback "<hello></hello>" `shouldParse` Arg "hello" (Callback [])
-      parse' callback `shouldFailOn` "<hello></there>"
+      parse callback "<hello></hello>" `shouldParse` Arg "hello" (Callback [])
+      parse callback `shouldFailOn` "<hello></there>"
 
     it "reports friendly error for bad closing tag" $ do
       let e i = errFancy i . fancy . ErrorCustom
 
-      parse' callback "<hello> there" `shouldFailWith` e 1 (NoClosingCallbackTag "hello")
-      parse' callback "<hello> </there>" `shouldFailWith` e 10 (BadClosingCallbackTag "hello" "there")
+      parse callback "<hello> there" `shouldFailWith` e 1 (NoClosingCallbackTag "hello")
+      parse callback "<hello> </there>" `shouldFailWith` e 10 (BadClosingCallbackTag "hello" "there")
 
     it "only accepts alphanumeric identifiers" $ do
-      parse' callback "<XyZ></XyZ>" `shouldParse` Arg "XyZ" (Callback [])
-      parse' callback `shouldFailOn` "<x y></x y>"
+      parse callback "<XyZ></XyZ>" `shouldParse` Arg "XyZ" (Callback [])
+      parse callback `shouldFailOn` "<x y></x y>"
 
   describe "plural" $ do
     it "disallows wildcard not at the end" $ do
-      parse' cardinalPluralCases `shouldSucceedOn` "=1 {foo} other {bar}"
-      parse' cardinalPluralCases `shouldFailOn` "other {bar} =1 {foo}"
+      parse cardinalPluralCases `shouldSucceedOn` "=1 {foo} other {bar}"
+      parse cardinalPluralCases `shouldFailOn` "other {bar} =1 {foo}"
 
     it "tolerates empty cases" $ do
-      parse' cardinalPluralCases `shouldSucceedOn` "=1 {} other {}"
+      parse cardinalPluralCases `shouldSucceedOn` "=1 {} other {}"
 
     it "requires at least one non-wildcard case" $ do
-      parse' cardinalPluralCases `shouldFailOn` "other {foo}"
-      parse' cardinalPluralCases `shouldSucceedOn` "=0 {foo} other {bar}"
-      parse' cardinalPluralCases `shouldSucceedOn` "one {foo} other {bar}"
+      parse cardinalPluralCases `shouldFailOn` "other {foo}"
+      parse cardinalPluralCases `shouldSucceedOn` "=0 {foo} other {bar}"
+      parse cardinalPluralCases `shouldSucceedOn` "one {foo} other {bar}"
 
     it "requires a wildcard if there are any rule cases" $ do
-      parse' cardinalPluralCases `shouldFailOn`    "=0 {foo} one {bar}"
-      parse' cardinalPluralCases `shouldSucceedOn` "=0 {foo} one {bar} other {baz}"
-      parse' cardinalPluralCases `shouldSucceedOn` "=0 {foo} =1 {bar}"
+      parse cardinalPluralCases `shouldFailOn`    "=0 {foo} one {bar}"
+      parse cardinalPluralCases `shouldSucceedOn` "=0 {foo} one {bar} other {baz}"
+      parse cardinalPluralCases `shouldSucceedOn` "=0 {foo} =1 {bar}"
 
     it "parses literal and plural cases, wildcard, and interpolation token" $ do
       parseWith (ParserState ["xyz"]) cardinalPluralCases "=0 {foo} few {bar} other {baz #}" `shouldParse`
@@ -151,20 +151,20 @@ spec = describe "parser" $ do
 
   describe "selectordinal" $ do
     it "disallows wildcard not at the end" $ do
-      parse' ordinalPluralCases `shouldSucceedOn` "one {foo} other {bar}"
-      parse' ordinalPluralCases `shouldFailOn` "other {bar} one {foo}"
+      parse ordinalPluralCases `shouldSucceedOn` "one {foo} other {bar}"
+      parse ordinalPluralCases `shouldFailOn` "other {bar} one {foo}"
 
     it "tolerates empty cases" $ do
-      parse' ordinalPluralCases `shouldSucceedOn` "one {} other {}"
+      parse ordinalPluralCases `shouldSucceedOn` "one {} other {}"
 
     it "requires at least one rule" $ do
-      parse' ordinalPluralCases `shouldFailOn` "other {foo}"
-      parse' ordinalPluralCases `shouldSucceedOn` "one {foo} other {bar}"
-      parse' ordinalPluralCases `shouldSucceedOn` "one {foo} two {bar} other {baz}"
+      parse ordinalPluralCases `shouldFailOn` "other {foo}"
+      parse ordinalPluralCases `shouldSucceedOn` "one {foo} other {bar}"
+      parse ordinalPluralCases `shouldSucceedOn` "one {foo} two {bar} other {baz}"
 
     it "requires a wildcard" $ do
-      parse' ordinalPluralCases `shouldFailOn`    "=0 {foo} one {bar}"
-      parse' ordinalPluralCases `shouldSucceedOn` "=0 {foo} one {bar} other {baz}"
+      parse ordinalPluralCases `shouldFailOn`    "=0 {foo} one {bar}"
+      parse ordinalPluralCases `shouldSucceedOn` "=0 {foo} one {bar} other {baz}"
 
     it "parses literal and plural cases, wildcard, and interpolation token" $ do
       parseWith (ParserState ["xyz"]) cardinalPluralCases "=0 {foo} few {bar} other {baz #}" `shouldParse`
@@ -172,13 +172,13 @@ spec = describe "parser" $ do
 
   describe "select" $ do
     it "disallows wildcard not at the end" $ do
-      parse' selectCases "foo {bar} other {baz}" `shouldParse` (pure (SelectCase "foo" [Plaintext "bar"]), Just (SelectWildcard [Plaintext "baz"]))
-      parse' selectCases `shouldFailOn` "other {bar} foo {baz}"
+      parse selectCases "foo {bar} other {baz}" `shouldParse` (pure (SelectCase "foo" [Plaintext "bar"]), Just (SelectWildcard [Plaintext "baz"]))
+      parse selectCases `shouldFailOn` "other {bar} foo {baz}"
 
     it "tolerates empty cases" $ do
-      parse' selectCases "x {} other {}" `shouldParse` (pure (SelectCase "x" []), Just (SelectWildcard []))
+      parse selectCases "x {} other {}" `shouldParse` (pure (SelectCase "x" []), Just (SelectWildcard []))
 
     it "requires at least one non-wildcard case" $ do
-      parse' selectCases "foo {bar}" `shouldParse` (pure (SelectCase "foo" [Plaintext "bar"]), Nothing)
-      parse' selectCases "foo {bar} other {baz}" `shouldParse` (pure (SelectCase "foo" [Plaintext "bar"]), Just (SelectWildcard [Plaintext "baz"]))
-      parse' selectCases `shouldFailOn` "other {foo}"
+      parse selectCases "foo {bar}" `shouldParse` (pure (SelectCase "foo" [Plaintext "bar"]), Nothing)
+      parse selectCases "foo {bar} other {baz}" `shouldParse` (pure (SelectCase "foo" [Plaintext "bar"]), Just (SelectWildcard [Plaintext "baz"]))
+      parse selectCases `shouldFailOn` "other {foo}"

--- a/test/Intlc/ParserSpec.hs
+++ b/test/Intlc/ParserSpec.hs
@@ -4,12 +4,12 @@ import           Intlc.ICU
 import           Intlc.Parser
 import           Prelude               hiding (ByteString)
 import           Test.Hspec
-import           Test.Hspec.Megaparsec
-import           Text.Megaparsec       (ParseErrorBundle, Parsec, parse)
+import           Test.Hspec.Megaparsec hiding (initialState)
+import           Text.Megaparsec       (ParseErrorBundle, runParserT)
 import           Text.Megaparsec.Error (ErrorFancy (ErrorCustom))
 
-parse' :: Parsec e s a -> s -> Either (ParseErrorBundle s e) a
-parse' = flip parse "test"
+parse' :: Parser a -> Text -> Either (ParseErrorBundle Text MessageParseErr) a
+parse' p x = evalState (runParserT p "test" x) initialState
 
 spec :: Spec
 spec = describe "parser" $ do


### PR DESCRIPTION
Fixes #65.

We have a recursive token parser. Previously to support `#` we tacked support on inside the plural parser with `<|>`. This worked for shallow usages, but not for nested/deep usages in which we'd recurse back around to the aforementioned token parser sans `#` support.

We now instead keep track of plural `State`. When we encounter `#` in that top-level token parser, we inspect what plural context we're in. If we're in one, we parse as an interpolation. If we're not, we fail/skip the parse leading to it parsing as plaintext.

In order to support `State` in our `Parser`, we now use the `ParsecT` type where the `T` stands for "transformer". The previously used `Parsec` type was a mere alias around this with the `Identity` monad instead of our `State` monad, hence how little code changed.