### PR TITLE
Optionally prepend react import if there is at least one TSX backend

### DIFF
--- a/.golden/e2e/example/golden.ts
+++ b/.golden/e2e/example/golden.ts
@@ -1,3 +1,2 @@
-import React, { ReactElement } from 'react'
 export const greeting: (x: { bold: (x: string) => string; name: string; age: number }) => string = x => `Hello ${x.bold(`${x.name}`)}, ${new Intl.NumberFormat('en-US').format(x.age)}!`
 export const title: () => string = () => 'Unsplash'

--- a/lib/Intlc/Backend/JavaScript/Compiler.hs
+++ b/lib/Intlc/Backend/JavaScript/Compiler.hs
@@ -1,7 +1,9 @@
-module Intlc.Backend.JavaScript.Compiler (InterpStrat (..), compileStmt, compileStmtPieces) where
+module Intlc.Backend.JavaScript.Compiler (InterpStrat (..), compileStmt, compileStmtPieces, buildReactImport) where
 
 import           Intlc.Backend.JavaScript.Language
-import           Intlc.Core                        (Locale (Locale))
+import           Intlc.Core                        (Backend (..),
+                                                    Dataset, Locale (Locale),
+                                                    Translation (Translation))
 import qualified Intlc.ICU                         as ICU
 import           Prelude                           hiding (Type, fromList)
 import           Utils                             ((<>^))
@@ -133,3 +135,12 @@ dateTimeFmt ICU.Short  = "short"
 dateTimeFmt ICU.Medium = "medium"
 dateTimeFmt ICU.Long   = "long"
 dateTimeFmt ICU.Full   = "full"
+
+isTypeScriptReact :: Translation -> Bool
+isTypeScriptReact (Translation _m  be) = case be of
+  TypeScript      -> False
+  TypeScriptReact -> True
+
+
+buildReactImport :: Dataset Translation -> Maybe Text
+buildReactImport = fmap (const "import React, { ReactElement } from 'react'") . find isTypeScriptReact

--- a/lib/Intlc/Backend/JavaScript/Compiler.hs
+++ b/lib/Intlc/Backend/JavaScript/Compiler.hs
@@ -137,10 +137,8 @@ dateTimeFmt ICU.Long   = "long"
 dateTimeFmt ICU.Full   = "full"
 
 isTypeScriptReact :: Translation -> Bool
-isTypeScriptReact (Translation _m  be) = case be of
-  TypeScript      -> False
-  TypeScriptReact -> True
-
+isTypeScriptReact (Translation _ TypeScriptReact) = True
+isTypeScriptReact _                               = False
 
 buildReactImport :: Dataset Translation -> Maybe Text
 buildReactImport = fmap (const "import React, { ReactElement } from 'react'") . find isTypeScriptReact

--- a/lib/Intlc/Backend/JavaScript/Compiler.hs
+++ b/lib/Intlc/Backend/JavaScript/Compiler.hs
@@ -1,5 +1,6 @@
 module Intlc.Backend.JavaScript.Compiler (InterpStrat (..), compileStmt, compileStmtPieces, buildReactImport) where
 
+import           Control.Monad.Extra               (pureIf)
 import           Intlc.Backend.JavaScript.Language
 import           Intlc.Core                        (Backend (..), Dataset,
                                                     Locale (Locale),
@@ -141,4 +142,5 @@ isTypeScriptReact (Translation _ TypeScriptReact) = True
 isTypeScriptReact _                               = False
 
 buildReactImport :: Dataset Translation -> Maybe Text
-buildReactImport = fmap (const "import React, { ReactElement } from 'react'") . find isTypeScriptReact
+buildReactImport = flip pureIf text . any isTypeScriptReact
+  where text = "import React, { ReactElement } from 'react'"

--- a/lib/Intlc/Backend/JavaScript/Compiler.hs
+++ b/lib/Intlc/Backend/JavaScript/Compiler.hs
@@ -1,8 +1,8 @@
 module Intlc.Backend.JavaScript.Compiler (InterpStrat (..), compileStmt, compileStmtPieces, buildReactImport) where
 
 import           Intlc.Backend.JavaScript.Language
-import           Intlc.Core                        (Backend (..),
-                                                    Dataset, Locale (Locale),
+import           Intlc.Core                        (Backend (..), Dataset,
+                                                    Locale (Locale),
                                                     Translation (Translation))
 import qualified Intlc.ICU                         as ICU
 import           Prelude                           hiding (Type, fromList)

--- a/lib/Intlc/Backend/TypeScript/Compiler.hs
+++ b/lib/Intlc/Backend/TypeScript/Compiler.hs
@@ -25,14 +25,14 @@ compileNamedExport x l k v =
 compileTypeof :: InterpStrat -> ICU.Message -> Text
 compileTypeof x = let o = fromStrat x in flip runReader o . typeof . fromMsg o
 
-isTsx :: Translation -> Bool
-isTsx (Translation _m  be) = case be of
+isTypeScriptReact :: Translation -> Bool
+isTypeScriptReact (Translation _m  be) = case be of
   TypeScript      -> False
   TypeScriptReact -> True
 
 
-buildReactImport :: Dataset Translation -> Text
-buildReactImport =  maybe "" (const ("import React, { ReactElement } from 'react'" <> "\n")) . find isTsx
+buildReactImport :: Dataset Translation -> Maybe Text
+buildReactImport = fmap (const "import React, { ReactElement } from 'react'") . find isTypeScriptReact
 
 fromStrat :: InterpStrat -> Out
 fromStrat TemplateLit = TUniOut TStr

--- a/lib/Intlc/Backend/TypeScript/Compiler.hs
+++ b/lib/Intlc/Backend/TypeScript/Compiler.hs
@@ -2,14 +2,14 @@
 -- look like. The value-level output is JavaScript and resides almost entirely
 -- in the corresponding module. They have been written with one-another in mind.
 
-module Intlc.Backend.TypeScript.Compiler (compileNamedExport, reactImport) where
+module Intlc.Backend.TypeScript.Compiler (compileNamedExport, buildReactImport) where
 
 import           Data.List                         (nubBy)
 import qualified Data.Text                         as T
 import           Intlc.Backend.JavaScript.Compiler (InterpStrat (..),
                                                     compileStmtPieces)
 import           Intlc.Backend.TypeScript.Language
-import           Intlc.Core                        (Locale)
+import           Intlc.Core
 import qualified Intlc.ICU                         as ICU
 import           Prelude                           hiding (Type)
 import           Utils                             ((<>^))
@@ -25,8 +25,14 @@ compileNamedExport x l k v =
 compileTypeof :: InterpStrat -> ICU.Message -> Text
 compileTypeof x = let o = fromStrat x in flip runReader o . typeof . fromMsg o
 
-reactImport :: Text
-reactImport = "import React, { ReactElement } from 'react'"
+isTsx :: Translation -> Bool
+isTsx (Translation _m  be) = case be of
+  TypeScript      -> False
+  TypeScriptReact -> True
+
+
+buildReactImport :: Dataset Translation -> Text
+buildReactImport =  maybe "" (const ("import React, { ReactElement } from 'react'" <> "\n")) . find isTsx . toList
 
 fromStrat :: InterpStrat -> Out
 fromStrat TemplateLit = TUniOut TStr

--- a/lib/Intlc/Backend/TypeScript/Compiler.hs
+++ b/lib/Intlc/Backend/TypeScript/Compiler.hs
@@ -32,7 +32,7 @@ isTsx (Translation _m  be) = case be of
 
 
 buildReactImport :: Dataset Translation -> Text
-buildReactImport =  maybe "" (const ("import React, { ReactElement } from 'react'" <> "\n")) . find isTsx . toList
+buildReactImport =  maybe "" (const ("import React, { ReactElement } from 'react'" <> "\n")) . find isTsx
 
 fromStrat :: InterpStrat -> Out
 fromStrat TemplateLit = TUniOut TStr

--- a/lib/Intlc/Backend/TypeScript/Compiler.hs
+++ b/lib/Intlc/Backend/TypeScript/Compiler.hs
@@ -2,7 +2,7 @@
 -- look like. The value-level output is JavaScript and resides almost entirely
 -- in the corresponding module. They have been written with one-another in mind.
 
-module Intlc.Backend.TypeScript.Compiler (compileNamedExport, buildReactImport) where
+module Intlc.Backend.TypeScript.Compiler (compileNamedExport) where
 
 import           Data.List                         (nubBy)
 import qualified Data.Text                         as T
@@ -24,15 +24,6 @@ compileNamedExport x l k v =
 
 compileTypeof :: InterpStrat -> ICU.Message -> Text
 compileTypeof x = let o = fromStrat x in flip runReader o . typeof . fromMsg o
-
-isTypeScriptReact :: Translation -> Bool
-isTypeScriptReact (Translation _m  be) = case be of
-  TypeScript      -> False
-  TypeScriptReact -> True
-
-
-buildReactImport :: Dataset Translation -> Maybe Text
-buildReactImport = fmap (const "import React, { ReactElement } from 'react'") . find isTypeScriptReact
 
 fromStrat :: InterpStrat -> Out
 fromStrat TemplateLit = TUniOut TStr

--- a/lib/Intlc/Compiler.hs
+++ b/lib/Intlc/Compiler.hs
@@ -13,11 +13,14 @@ import           Intlc.Core
 import qualified Intlc.ICU                         as ICU
 import           Prelude                           hiding (ByteString)
 
+prependOptionalReactImport :: Dataset Translation -> Text
+prependOptionalReactImport = maybe "" (<> "\n") . TS.buildReactImport
+
 -- We'll `foldr` with `mempty`, avoiding `mconcat`, to preserve insertion order.
 -- The `""` base case in `merge` prevents a spare newline, acting like
 -- intercalation.
 compileDataset :: Locale -> Dataset Translation -> Either (NonEmpty Text) Text
-compileDataset l d = fmap (TS.buildReactImport d <>) . M.foldrWithKey ((merge .) . translation l) (Right mempty) $ d
+compileDataset l d = fmap (prependOptionalReactImport d <>) . M.foldrWithKey ((merge .) . translation l) (Right mempty) $ d
   where
         -- Merge two `Right`s, essentially intercalating with newlines (hence
         -- the empty accumulator base case).

--- a/lib/Intlc/Compiler.hs
+++ b/lib/Intlc/Compiler.hs
@@ -7,14 +7,14 @@ import           Data.List.Extra                   (firstJust)
 import qualified Data.Map                          as M
 import           Intlc.Backend.Common              (validateArgs)
 import           Intlc.Backend.ICU.Compiler        (compileMsg)
-import           Intlc.Backend.JavaScript.Compiler (InterpStrat (..))
+import           Intlc.Backend.JavaScript.Compiler as JS
 import qualified Intlc.Backend.TypeScript.Compiler as TS
 import           Intlc.Core
 import qualified Intlc.ICU                         as ICU
 import           Prelude                           hiding (ByteString)
 
 prependOptionalReactImport :: Dataset Translation -> Text
-prependOptionalReactImport = maybe "" (<> "\n") . TS.buildReactImport
+prependOptionalReactImport = maybe "" (<> "\n") . JS.buildReactImport
 
 -- We'll `foldr` with `mempty`, avoiding `mconcat`, to preserve insertion order.
 -- The `""` base case in `merge` prevents a spare newline, acting like

--- a/lib/Intlc/Compiler.hs
+++ b/lib/Intlc/Compiler.hs
@@ -17,7 +17,7 @@ import           Prelude                           hiding (ByteString)
 -- The `""` base case in `merge` prevents a spare newline, acting like
 -- intercalation.
 compileDataset :: Locale -> Dataset Translation -> Either (NonEmpty Text) Text
-compileDataset l = fmap ((TS.reactImport <> "\n") <>) . M.foldrWithKey ((merge .) . translation l) (Right mempty)
+compileDataset l d = fmap (TS.buildReactImport d <>) . M.foldrWithKey ((merge .) . translation l) (Right mempty) $ d
   where
         -- Merge two `Right`s, essentially intercalating with newlines (hence
         -- the empty accumulator base case).

--- a/lib/Intlc/Compiler.hs
+++ b/lib/Intlc/Compiler.hs
@@ -14,7 +14,7 @@ import qualified Intlc.ICU                         as ICU
 import           Prelude                           hiding (ByteString)
 
 prependOptionalReactImport :: Dataset Translation -> Text
-prependOptionalReactImport = maybe "" (<> "\n") . JS.buildReactImport
+prependOptionalReactImport = foldMap (<> "\n") . JS.buildReactImport
 
 -- We'll `foldr` with `mempty`, avoiding `mconcat`, to preserve insertion order.
 -- The `""` base case in `merge` prevents a spare newline, acting like

--- a/test/Intlc/EndToEndSpec.hs
+++ b/test/Intlc/EndToEndSpec.hs
@@ -38,39 +38,39 @@ spec = describe "end-to-end" $ do
 
   it "parses and discards descriptions" $ do
     [r|{ "brand": { "message": "Unsplash", "description": "The company name" } }|]
-      =*= withReactImport "export const brand: () => string = () => 'Unsplash'"
+      =*= "export const brand: () => string = () => 'Unsplash'"
 
   it "outputs in alphabetical order" $ do
     [r|{ "x": { "message": "" }, "A": { "message": "" }, "z": { "message": "" } }|]
-      =*= withReactImport "export const A: () => string = () => ''\nexport const x: () => string = () => ''\nexport const z: () => string = () => ''"
+      =*= "export const A: () => string = () => ''\nexport const x: () => string = () => ''\nexport const z: () => string = () => ''"
 
   it "compiles plurals" $ do
     [r|{ "prop": { "message": "Age: {age, plural, =0 {newborn called {name}} =42 {magical} other {boring #}}", "backend": "ts" } }|]
-      =*= withReactImport "export const prop: (x: { age: number; name: string }) => string = x => `Age: ${(() => { switch (x.age) { case 0: return `newborn called ${x.name}`; case 42: return `magical`; default: return `boring ${new Intl.NumberFormat('en-US').format(x.age)}`; } })()}`"
+      =*= "export const prop: (x: { age: number; name: string }) => string = x => `Age: ${(() => { switch (x.age) { case 0: return `newborn called ${x.name}`; case 42: return `magical`; default: return `boring ${new Intl.NumberFormat('en-US').format(x.age)}`; } })()}`"
     [r|{ "prop": { "message": "Age: {age, plural, =0 {newborn called {name}} =42 {magical} other {boring #}}", "backend": "tsx" } }|]
       =*= withReactImport "export const prop: (x: { age: number; name: string }) => ReactElement = x => <>Age: {(() => { switch (x.age) { case 0: return <>newborn called {x.name}</>; case 42: return <>magical</>; default: return <>boring {new Intl.NumberFormat('en-US').format(x.age)}</>; } })()}</>"
     [r|{ "f": { "message": "{n, plural, =0 {x} =42 {y}}", "backend": "ts" } }|]
-      =*= withReactImport "export const f: (x: { n: 0 | 42 }) => string = x => `${(() => { switch (x.n) { case 0: return `x`; case 42: return `y`; } })()}`"
+      =*= "export const f: (x: { n: 0 | 42 }) => string = x => `${(() => { switch (x.n) { case 0: return `x`; case 42: return `y`; } })()}`"
     [r|{ "f": { "message": "{n, plural, =0 {zero} many {many} other {#}}", "backend": "ts" } }|]
-      =*= withReactImport "export const f: (x: { n: number }) => string = x => `${(() => { switch (x.n) { case 0: return `zero`; default: { switch (new Intl.PluralRules('en-US').select(x.n)) { case 'many': return `many`; default: return `${new Intl.NumberFormat('en-US').format(x.n)}`; } } } })()}`"
+      =*= "export const f: (x: { n: number }) => string = x => `${(() => { switch (x.n) { case 0: return `zero`; default: { switch (new Intl.PluralRules('en-US').select(x.n)) { case 'many': return `many`; default: return `${new Intl.NumberFormat('en-US').format(x.n)}`; } } } })()}`"
     [r|{ "f": { "message": "{n, plural, many {many} other {#}}", "backend": "ts" } }|]
-      =*= withReactImport "export const f: (x: { n: number }) => string = x => `${(() => { switch (new Intl.PluralRules('en-US').select(x.n)) { case 'many': return `many`; default: return `${new Intl.NumberFormat('en-US').format(x.n)}`; } })()}`"
+      =*= "export const f: (x: { n: number }) => string = x => `${(() => { switch (new Intl.PluralRules('en-US').select(x.n)) { case 'many': return `many`; default: return `${new Intl.NumberFormat('en-US').format(x.n)}`; } })()}`"
 
   it "compiles select" $ do
     [r|{ "f": { "message": "{x, select, a {hi} b {yo}}", "backend": "ts" } }|]
-      =*= withReactImport "export const f: (x: { x: 'a' | 'b' }) => string = x => `${(() => { switch (x.x) { case 'a': return `hi`; case 'b': return `yo`; } })()}`"
+      =*= "export const f: (x: { x: 'a' | 'b' }) => string = x => `${(() => { switch (x.x) { case 'a': return `hi`; case 'b': return `yo`; } })()}`"
     [r|{ "f": { "message": "{x, select, a {hi} b {yo} other {ciao}}", "backend": "ts" } }|]
-      =*= withReactImport "export const f: (x: { x: string }) => string = x => `${(() => { switch (x.x) { case 'a': return `hi`; case 'b': return `yo`; default: return `ciao`; } })()}`"
+      =*= "export const f: (x: { x: string }) => string = x => `${(() => { switch (x.x) { case 'a': return `hi`; case 'b': return `yo`; default: return `ciao`; } })()}`"
 
   it "compiles selectordinal" $ do
     [r|{ "f": { "message": "{x, selectordinal, one {foo} other {bar}}", "backend": "ts" } }|]
-      =*= withReactImport "export const f: (x: { x: number }) => string = x => `${(() => { switch (new Intl.PluralRules('en-US', { type: 'ordinal' }).select(x.x)) { case 'one': return `foo`; default: return `bar`; } })()}`"
+      =*= "export const f: (x: { x: number }) => string = x => `${(() => { switch (new Intl.PluralRules('en-US', { type: 'ordinal' }).select(x.x)) { case 'one': return `foo`; default: return `bar`; } })()}`"
     [r|{ "f": { "message": "{x, selectordinal, one {foo} =2 {bar} other {baz}}", "backend": "ts" } }|]
-      =*= withReactImport "export const f: (x: { x: number }) => string = x => `${(() => { switch (x.x) { case 2: return `bar`; default: { switch (new Intl.PluralRules('en-US', { type: 'ordinal' }).select(x.x)) { case 'one': return `foo`; default: return `baz`; } } } })()}`"
+      =*= "export const f: (x: { x: number }) => string = x => `${(() => { switch (x.x) { case 2: return `bar`; default: { switch (new Intl.PluralRules('en-US', { type: 'ordinal' }).select(x.x)) { case 'one': return `foo`; default: return `baz`; } } } })()}`"
 
   it "TypeScript backend" $ do
     [r|{ "f": { "message": "{x} <z>{y, number}</z> {y, number}", "backend": "ts" } }|]
-      =*= withReactImport "export const f: (x: { x: string; z: (x: string) => string; y: number }) => string = x => `${x.x} ${x.z(`${new Intl.NumberFormat('en-US').format(x.y)}`)} ${new Intl.NumberFormat('en-US').format(x.y)}`"
+      =*= "export const f: (x: { x: string; z: (x: string) => string; y: number }) => string = x => `${x.x} ${x.z(`${new Intl.NumberFormat('en-US').format(x.y)}`)} ${new Intl.NumberFormat('en-US').format(x.y)}`"
 
   it "TypeScriptReact backend" $ do
     [r|{ "f": { "message": "{x} <z>{y, number}</z>", "backend": "tsx" } }|]


### PR DESCRIPTION
Only prepend a react import once when there is at least one TSX backend

Again, this may not be idiomatic haskell 😅 

## TODO

- [ ] ~~Forgot to keep `ReactElement`~~