### PR TITLE
Remove dangling React import

### DIFF
--- a/lib/Intlc/Backend/JavaScript/Compiler.hs
+++ b/lib/Intlc/Backend/JavaScript/Compiler.hs
@@ -143,4 +143,4 @@ isTypeScriptReact _                               = False
 
 buildReactImport :: Dataset Translation -> Maybe Text
 buildReactImport = flip pureIf text . any isTypeScriptReact
-  where text = "import React, { ReactElement } from 'react'"
+  where text = "import { ReactElement } from 'react'"

--- a/test/Intlc/EndToEndSpec.hs
+++ b/test/Intlc/EndToEndSpec.hs
@@ -29,7 +29,7 @@ golden name in' = baseCfg
 x =*= y = parseAndCompileDataset x `shouldBe` Right y
 
 withReactImport :: Text -> Text
-withReactImport = ("import React, { ReactElement } from 'react'\n" <>)
+withReactImport = ("import { ReactElement } from 'react'\n" <>)
 
 spec :: Spec
 spec = describe "end-to-end" $ do


### PR DESCRIPTION
With the new JSX transform we don't need React in scope to correctly
turn JSX into function calls https://reactjs.org/blog/2020/09/22/introducing-the-new-jsx-transform.html
