### PR TITLE
Preserve "description" key when flattening

### DIFF
--- a/lib/Intlc/Backend/JavaScript/Compiler.hs
+++ b/lib/Intlc/Backend/JavaScript/Compiler.hs
@@ -4,7 +4,7 @@ import           Control.Monad.Extra               (pureIf)
 import           Intlc.Backend.JavaScript.Language
 import           Intlc.Core                        (Backend (..), Dataset,
                                                     Locale (Locale),
-                                                    Translation (Translation))
+                                                    Translation (backend))
 import qualified Intlc.ICU                         as ICU
 import           Prelude                           hiding (Type, fromList)
 import           Utils                             ((<>^))
@@ -137,10 +137,6 @@ dateTimeFmt ICU.Medium = "medium"
 dateTimeFmt ICU.Long   = "long"
 dateTimeFmt ICU.Full   = "full"
 
-isTypeScriptReact :: Translation -> Bool
-isTypeScriptReact (Translation _ TypeScriptReact) = True
-isTypeScriptReact _                               = False
-
 buildReactImport :: Dataset Translation -> Maybe Text
-buildReactImport = flip pureIf text . any isTypeScriptReact
+buildReactImport = flip pureIf text . any ((TypeScriptReact ==) . backend)
   where text = "import { ReactElement } from 'react'"

--- a/lib/Intlc/Compiler.hs
+++ b/lib/Intlc/Compiler.hs
@@ -33,7 +33,7 @@ compileDataset l d = fmap (prependOptionalReactImport d <>) . M.foldrWithKey ((m
         merge (Right _) es@(Left _) = es
 
 translation :: Locale -> Text -> Translation -> Either (NonEmpty Text) Text
-translation l k (Translation v be) = validateArgs (args v) $> case be of
+translation l k (Translation v be _) = validateArgs (args v) $> case be of
   TypeScript      -> TS.compileNamedExport TemplateLit l k v
   TypeScriptReact -> TS.compileNamedExport JSX         l k v
 
@@ -49,7 +49,7 @@ compileFlattened :: Dataset Translation -> ByteString
 compileFlattened = encode . flattenDataset
 
 flattenDataset :: Dataset Translation -> Dataset UnparsedTranslation
-flattenDataset = fmap $ \(Translation msg be) -> UnparsedTranslation (compileMsg . flatten $ msg) be
+flattenDataset = fmap $ \(Translation msg be md) -> UnparsedTranslation (compileMsg . flatten $ msg) be md
 
 flatten :: ICU.Message -> ICU.Message
 flatten x@(ICU.Static _)      = x

--- a/lib/Intlc/Core.hs
+++ b/lib/Intlc/Core.hs
@@ -35,6 +35,7 @@ instance ToJSON Backend where
 data UnparsedTranslation = UnparsedTranslation
   { umessage :: UnparsedMessage
   , ubackend :: Backend
+  , umdesc   :: Maybe Text
   }
   deriving (Show, Eq, Generic)
 
@@ -43,15 +44,18 @@ instance FromJSON UnparsedTranslation where
     where decode x = UnparsedTranslation
             <$> x .: "message"
             <*> x .:? "backend" .!= TypeScript
+            <*> x .:? "description"
 
 instance ToJSON UnparsedTranslation where
-  toEncoding (UnparsedTranslation msg be) = pairs $
-       "message" .= msg
-    <> "backend" .= be
+  toEncoding (UnparsedTranslation msg be md) = pairs $
+       "message"     .= msg
+    <> "backend"     .= be
+    <> "description" .= md
 
 data Translation = Translation
   { message :: Message
   , backend :: Backend
+  , mdesc   :: Maybe Text
   }
   deriving (Show, Eq)
 

--- a/lib/Intlc/Parser.hs
+++ b/lib/Intlc/Parser.hs
@@ -59,8 +59,9 @@ validateKeys xs = toEither . nonEmpty . filter (not . isValidKey) . M.keys $ xs
         isValidKey = T.all (liftA2 (||) isAlpha (== '_'))
 
 parseTranslationFor :: Text -> UnparsedTranslation -> Either ParseErr Translation
-parseTranslationFor name (UnparsedTranslation umsg be) =
-  flip Translation be <$> evalState (runParserT msg (T.unpack name) umsg) initialState
+parseTranslationFor name (UnparsedTranslation umsg be md) = do
+  msg' <- evalState (runParserT msg (T.unpack name) umsg) initialState
+  pure $ Translation msg' be md
 
 type ParseErr = ParseErrorBundle Text MessageParseErr
 


### PR DESCRIPTION
Not a ton of thought put into this, a quick fix to unblock. Note that absent description keys will be output as `"description": null`.