### PR TITLE
Output a valid JS module when compiled output is empty

### DIFF
--- a/lib/Intlc/Backend/JavaScript/Compiler.hs
+++ b/lib/Intlc/Backend/JavaScript/Compiler.hs
@@ -1,4 +1,4 @@
-module Intlc.Backend.JavaScript.Compiler (InterpStrat (..), compileStmt, compileStmtPieces, buildReactImport) where
+module Intlc.Backend.JavaScript.Compiler (InterpStrat (..), compileStmt, compileStmtPieces, buildReactImport, emptyModule) where
 
 import           Control.Monad.Extra               (pureIf)
 import           Intlc.Backend.JavaScript.Language
@@ -136,6 +136,10 @@ dateTimeFmt ICU.Short  = "short"
 dateTimeFmt ICU.Medium = "medium"
 dateTimeFmt ICU.Long   = "long"
 dateTimeFmt ICU.Full   = "full"
+
+-- A no-op that clarifies a JS/TS file as an ES module.
+emptyModule :: Text
+emptyModule = "export {}"
 
 buildReactImport :: Dataset Translation -> Maybe Text
 buildReactImport = flip pureIf text . any ((TypeScriptReact ==) . backend)

--- a/lib/Intlc/Compiler.hs
+++ b/lib/Intlc/Compiler.hs
@@ -15,7 +15,10 @@ import           Prelude                           hiding (ByteString)
 
 -- We'll `foldr` with `mempty`, avoiding `mconcat`, to preserve insertion order.
 compileDataset :: Locale -> Dataset Translation -> Text
-compileDataset l d = T.intercalate "\n" stmts
+compileDataset l d =
+  case stmts of
+    []     -> JS.emptyModule
+    stmts' -> T.intercalate "\n" stmts'
   where stmts = imports <> exports
         imports = maybeToList $ JS.buildReactImport d
         exports = M.foldrWithKey translationCons mempty d

--- a/test/Intlc/CompilerSpec.hs
+++ b/test/Intlc/CompilerSpec.hs
@@ -1,18 +1,12 @@
 module Intlc.CompilerSpec (spec) where
 
-import           Intlc.Backend.JavaScript.Compiler (emptyModule)
-import           Intlc.Compiler                    (compileDataset, flatten)
-import           Intlc.Core                        (Locale (Locale))
+import           Intlc.Compiler (flatten)
 import           Intlc.ICU
-import           Prelude                           hiding (one)
+import           Prelude        hiding (one)
 import           Test.Hspec
 
 spec :: Spec
 spec = describe "compiler" $ do
-  describe "compileDataset" $ do
-    it "compiles empty dataset to valid JS module format" $ do
-      compileDataset (Locale "foo") mempty `shouldBe` emptyModule
-
   describe "flatten" $ do
     it "no-ops static" $ do
       flatten (Static "xyz") `shouldBe` Static "xyz"

--- a/test/Intlc/CompilerSpec.hs
+++ b/test/Intlc/CompilerSpec.hs
@@ -1,12 +1,18 @@
 module Intlc.CompilerSpec (spec) where
 
-import           Intlc.Compiler (flatten)
+import           Intlc.Backend.JavaScript.Compiler (emptyModule)
+import           Intlc.Compiler                    (compileDataset, flatten)
+import           Intlc.Core                        (Locale (Locale))
 import           Intlc.ICU
-import           Prelude        hiding (one)
+import           Prelude                           hiding (one)
 import           Test.Hspec
 
 spec :: Spec
 spec = describe "compiler" $ do
+  describe "compileDataset" $ do
+    it "compiles empty dataset to valid JS module format" $ do
+      compileDataset (Locale "foo") mempty `shouldBe` emptyModule
+
   describe "flatten" $ do
     it "no-ops static" $ do
       flatten (Static "xyz") `shouldBe` Static "xyz"

--- a/test/Intlc/EndToEndSpec.hs
+++ b/test/Intlc/EndToEndSpec.hs
@@ -40,6 +40,10 @@ spec = describe "end-to-end" $ do
     parseDataset [r|{ "x bad key": { "message": "foo" }, "good_Key": { "message": "bar" }, "y-bad-key": { "message": "baz" }, "z_bad_key123": { "message": "biz" } }|] `shouldBe`
       Left (InvalidKeys $ "x bad key" :| ["y-bad-key", "z_bad_key123"])
 
+  it "compiles valid JS module format given empty input" $ do
+    [r|{}|]
+      =*= "export {}"
+
   it "parses and discards descriptions" $ do
     [r|{ "brand": { "message": "Unsplash", "description": "The company name" } }|]
       =*= "export const brand: () => string = () => 'Unsplash'"


### PR DESCRIPTION
Fixes #78.

Some refactoring is probably warranted so that `Intlc.Compiler` becomes agnostic to our compilers, and `Intlc.Backend.JavaScript.Compiler` itself would become responsible for things like this and the React import. But that's not a priority whilst we only use TS(X) output. :see_no_evil: 