### PR TITLE
Fix TSX backend output when there are no interpolations

### DIFF
--- a/.golden/e2e/example/golden.ts
+++ b/.golden/e2e/example/golden.ts
@@ -1,2 +1,2 @@
 export const greeting: (x: { age: number; bold: (x: string) => string; name: string }) => string = x => `Hello ${x.bold(`${x.name}`)}, ${new Intl.NumberFormat('en-US').format(x.age)}!`
-export const title: () => string = () => 'Unsplash'
+export const title: () => string = () => `Unsplash`

--- a/lib/Intlc/Backend/JavaScript/Compiler.hs
+++ b/lib/Intlc/Backend/JavaScript/Compiler.hs
@@ -77,8 +77,7 @@ stmt = fmap f . stmtPieces
   where f (n, r) = "export const " <> n <> " = " <> r
 
 stmtPieces :: Stmt -> Compiler (Text, Text)
-stmtPieces (Stmt n ((TPrint x):|[])) = pure (n, "'" <> x <> "'")
-stmtPieces (Stmt n xs)               = (n, ) <$> (wrap =<< exprs xs)
+stmtPieces (Stmt n xs) = (n, ) <$> (wrap =<< exprs xs)
 
 exprs :: Foldable f => f Expr -> Compiler Text
 exprs = foldMapM expr

--- a/test/Intlc/EndToEndSpec.hs
+++ b/test/Intlc/EndToEndSpec.hs
@@ -42,11 +42,11 @@ spec = describe "end-to-end" $ do
 
   it "parses and discards descriptions" $ do
     [r|{ "brand": { "message": "Unsplash", "description": "The company name" } }|]
-      =*= "export const brand: () => string = () => 'Unsplash'"
+      =*= "export const brand: () => string = () => `Unsplash`"
 
   it "outputs in alphabetical order" $ do
     [r|{ "x": { "message": "" }, "A": { "message": "" }, "z": { "message": "" } }|]
-      =*= "export const A: () => string = () => ''\nexport const x: () => string = () => ''\nexport const z: () => string = () => ''"
+      =*= "export const A: () => string = () => ``\nexport const x: () => string = () => ``\nexport const z: () => string = () => ``"
 
   it "compiles plurals" $ do
     [r|{ "prop": { "message": "Age: {age, plural, =0 {newborn called {name}} =42 {magical} other {boring #}}", "backend": "ts" } }|]


### PR DESCRIPTION
Fixes #83. See commit message for rationale.

Alongside the removal of single quotes visible in the diff, the core issue addressed is as follows.

Given `{ "foo": { "backend": "tsx", "message": "bar" } }`...

Before: `export const foo: () => ReactElement = () => 'bar'`

After: `export const foo: () => ReactElement = () => <>bar</>`

This also makes #82 a substantially lesser bug given how much more rarely used a backtick is in copy.