### PR TITLE
Improved key validation: Emptiness, reserved words, and beyond JavaScript

### DIFF
--- a/cli/Main.hs
+++ b/cli/Main.hs
@@ -1,6 +1,7 @@
 module Main where
 
 import           CLI            (Opts (..), getOpts)
+import qualified Data.Text      as T
 import           Intlc.Compiler (compileDataset, compileFlattened)
 import           Intlc.Core
 import           Intlc.Parser   (ParseFailure, parseDataset, printErr)
@@ -10,8 +11,9 @@ main :: IO ()
 main = getOpts >>= \case
   Compile path loc -> tryCompile loc =<< getParsed path
   Flatten path -> either parserDie (putLBSLn . compileFlattened) =<< getParsed path
-  where tryCompile l = either parserDie (putTextLn . compileDataset l)
+  where tryCompile l = either parserDie (either compilerDie putTextLn . compileDataset l)
         parserDie = die . printErr
+        compilerDie = die . T.unpack . ("Invalid keys: " <>) . T.intercalate ", " . toList
 
 getParsed :: FilePath -> IO (Either ParseFailure (Dataset Translation))
 getParsed = fmap parseDataset . readFileLBS

--- a/cli/Main.hs
+++ b/cli/Main.hs
@@ -13,7 +13,7 @@ main = getOpts >>= \case
   Flatten path -> either parserDie (putLBSLn . compileFlattened) =<< getParsed path
   where tryCompile l = either parserDie (either compilerDie putTextLn . compileDataset l)
         parserDie = die . printErr
-        compilerDie = die . T.unpack . ("Invalid keys: " <>) . T.intercalate ", " . toList
+        compilerDie = die . T.unpack . ("Invalid keys:\n" <>) . T.intercalate "\n" . fmap ("\t" <>) . toList
 
 getParsed :: FilePath -> IO (Either ParseFailure (Dataset Translation))
 getParsed = fmap parseDataset . readFileLBS

--- a/lib/Intlc/Backend/JavaScript/Compiler.hs
+++ b/lib/Intlc/Backend/JavaScript/Compiler.hs
@@ -1,6 +1,8 @@
-module Intlc.Backend.JavaScript.Compiler (InterpStrat (..), compileStmt, compileStmtPieces, buildReactImport, emptyModule) where
+module Intlc.Backend.JavaScript.Compiler (InterpStrat (..), compileStmt, compileStmtPieces, buildReactImport, emptyModule, validateKey) where
 
 import           Control.Monad.Extra               (pureIf)
+import           Data.Char                         (isAlpha)
+import qualified Data.Text                         as T
 import           Intlc.Backend.JavaScript.Language
 import           Intlc.Core                        (Backend (..), Dataset,
                                                     Locale (Locale),
@@ -143,3 +145,9 @@ emptyModule = "export {}"
 buildReactImport :: Dataset Translation -> Maybe Text
 buildReactImport = flip pureIf text . any ((TypeScriptReact ==) . backend)
   where text = "import { ReactElement } from 'react'"
+
+validateKey :: Text -> Either Text ()
+validateKey k
+  | T.all isValidChar k = Right ()
+  | otherwise           = Left $ k <> ": invalid character(s) present."
+  where isValidChar = liftA2 (||) isAlpha (== '_')

--- a/lib/Intlc/Backend/JavaScript/Compiler.hs
+++ b/lib/Intlc/Backend/JavaScript/Compiler.hs
@@ -148,6 +148,85 @@ buildReactImport = flip pureIf text . any ((TypeScriptReact ==) . backend)
 
 validateKey :: Text -> Either Text ()
 validateKey k
-  | T.all isValidChar k = Right ()
-  | otherwise           = Left $ k <> ": invalid character(s) present."
+  | k `elem` reservedWords      = Left $ k <> ": reserved word."
+  | T.any (not . isValidChar) k = Left $ k <> ": invalid character(s) present."
+  | otherwise                   = Right ()
   where isValidChar = liftA2 (||) isAlpha (== '_')
+
+-- Useful docs:
+--   https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#keywords
+reservedWords :: [Text]
+reservedWords = es2015 <> future <> module' <> legacy <> literals where
+  es2015 =
+    [ "break"
+    , "case"
+    , "catch"
+    , "class"
+    , "const"
+    , "continue"
+    , "debugger"
+    , "default"
+    , "delete"
+    , "do"
+    , "else"
+    , "export"
+    , "extends"
+    , "finally"
+    , "for"
+    , "function"
+    , "if"
+    , "import"
+    , "in"
+    , "instanceof"
+    , "new"
+    , "return"
+    , "super"
+    , "switch"
+    , "this"
+    , "throw"
+    , "try"
+    , "typeof"
+    , "var"
+    , "void"
+    , "while"
+    , "with"
+    , "yield"
+    ]
+  future =
+    [ "enum"
+    , "implements"
+    , "interface"
+    , "let"
+    , "package"
+    , "private"
+    , "protected"
+    , "public"
+    , "static"
+    , "yield"
+    ]
+  module' =
+    [ "await"
+    ]
+  legacy =
+    [ "abstract"
+    , "boolean"
+    , "byte"
+    , "char"
+    , "double"
+    , "final"
+    , "float"
+    , "goto"
+    , "int"
+    , "long"
+    , "native"
+    , "short"
+    , "synchronized"
+    , "throws"
+    , "transient"
+    , "volatile"
+    ]
+  literals =
+    [ "null"
+    , "true"
+    , "false"
+    ]

--- a/lib/Intlc/Compiler.hs
+++ b/lib/Intlc/Compiler.hs
@@ -21,8 +21,8 @@ compileDataset l d = validateKeys d $>
     stmts' -> T.intercalate "\n" stmts'
   where stmts = imports <> exports
         imports = maybeToList $ JS.buildReactImport d
-        exports = M.foldrWithKey translationCons mempty d
-        translationCons k v acc = translation l k v : acc
+        exports = M.foldrWithKey buildCompiledTranslations mempty d
+        buildCompiledTranslations k v acc = compileTranslation l k v : acc
 
 validateKeys :: Dataset Translation -> Either (NonEmpty Text) ()
 validateKeys = toEither . lefts . fmap (uncurry validate) . M.toList
@@ -32,8 +32,8 @@ validateKeys = toEither . lefts . fmap (uncurry validate) . M.toList
           TypeScript      -> TS.validateKey
           TypeScriptReact -> TS.validateKey
 
-translation :: Locale -> Text -> Translation -> Text
-translation l k (Translation v be _) = case be of
+compileTranslation :: Locale -> Text -> Translation -> Text
+compileTranslation l k (Translation v be _) = case be of
   TypeScript      -> TS.compileNamedExport TemplateLit l k v
   TypeScriptReact -> TS.compileNamedExport JSX         l k v
 

--- a/lib/Intlc/Compiler.hs
+++ b/lib/Intlc/Compiler.hs
@@ -24,11 +24,13 @@ compileDataset l d = validateKeys d $>
         exports = M.foldrWithKey translationCons mempty d
         translationCons k v acc = translation l k v : acc
 
-validateKeys :: Dataset a -> Either (NonEmpty Text) ()
-validateKeys = toEither . lefts . fmap JS.validateKey . M.keys
+validateKeys :: Dataset Translation -> Either (NonEmpty Text) ()
+validateKeys = toEither . lefts . fmap (uncurry validate) . M.toList
   where toEither []     = Right ()
         toEither (e:es) = Left $ e :| es
-
+        validate k t = k & case backend t of
+          TypeScript      -> TS.validateKey
+          TypeScriptReact -> TS.validateKey
 
 translation :: Locale -> Text -> Translation -> Text
 translation l k (Translation v be _) = case be of

--- a/lib/Intlc/Parser.hs
+++ b/lib/Intlc/Parser.hs
@@ -10,7 +10,6 @@ module Intlc.Parser where
 import qualified Control.Applicative.Combinators.NonEmpty as NE
 import           Data.Aeson                               (decode)
 import           Data.ByteString.Lazy                     (ByteString)
-import           Data.Char                                (isAlpha)
 import qualified Data.Map                                 as M
 import qualified Data.Text                                as T
 import           Data.Void                                ()
@@ -26,7 +25,6 @@ import           Text.Megaparsec.Error.Builder
 
 data ParseFailure
   = FailedJsonParse
-  | InvalidKeys (NonEmpty Text)
   | FailedMessageParse ParseErr
   deriving (Show, Eq)
 
@@ -44,19 +42,12 @@ pos `failingWith` e = parseError . errFancy pos . fancy . ErrorCustom $ e
 
 printErr :: ParseFailure -> String
 printErr FailedJsonParse        = "Failed to parse JSON"
-printErr (InvalidKeys ks)       = T.unpack $ "Invalid keys: " <> T.intercalate ", " (toList ks)
 printErr (FailedMessageParse e) = errorBundlePretty e
 
 parseDataset :: ByteString -> Either ParseFailure (Dataset Translation)
-parseDataset = parse' <=< validateKeys <=< decode'
+parseDataset = parse' <=< decode'
   where decode' = maybeToRight FailedJsonParse . decode
         parse' = M.traverseWithKey ((first FailedMessageParse .) . parseTranslationFor)
-
-validateKeys :: Dataset a -> Either ParseFailure (Dataset a)
-validateKeys xs = toEither . nonEmpty . filter (not . isValidKey) . M.keys $ xs
-  where toEither Nothing   = Right xs
-        toEither (Just ks) = Left . InvalidKeys $ ks
-        isValidKey = T.all (liftA2 (||) isAlpha (== '_'))
 
 parseTranslationFor :: Text -> UnparsedTranslation -> Either ParseErr Translation
 parseTranslationFor name (UnparsedTranslation umsg be md) = do

--- a/test/Intlc/CompilerSpec.hs
+++ b/test/Intlc/CompilerSpec.hs
@@ -16,6 +16,9 @@ spec = describe "compiler" $ do
       f ["goodKey"] `shouldSatisfy` isRight
       f ["bad key"] `shouldSatisfy` isLeft
 
+    it "validates keys aren't reserved words" $ do
+      f ["delete"] `shouldSatisfy` isLeft
+
   describe "flatten" $ do
     it "no-ops static" $ do
       flatten (Static "xyz") `shouldBe` Static "xyz"

--- a/test/Intlc/CompilerSpec.hs
+++ b/test/Intlc/CompilerSpec.hs
@@ -19,6 +19,9 @@ spec = describe "compiler" $ do
     it "validates keys aren't reserved words" $ do
       f ["delete"] `shouldSatisfy` isLeft
 
+    it "validates keys aren't empty" $ do
+      f [""] `shouldSatisfy` isLeft
+
   describe "flatten" $ do
     it "no-ops static" $ do
       flatten (Static "xyz") `shouldBe` Static "xyz"

--- a/test/Intlc/CompilerSpec.hs
+++ b/test/Intlc/CompilerSpec.hs
@@ -1,12 +1,21 @@
 module Intlc.CompilerSpec (spec) where
 
-import           Intlc.Compiler (flatten)
+import           Intlc.Compiler (compileDataset, flatten)
+import           Intlc.Core     (Backend (TypeScript), Locale (Locale),
+                                 Translation (Translation))
 import           Intlc.ICU
 import           Prelude        hiding (one)
 import           Test.Hspec
 
 spec :: Spec
 spec = describe "compiler" $ do
+  describe "compile" $ do
+    let f = compileDataset (Locale "any") . fromList . fmap (, Translation (Static "any") TypeScript Nothing)
+
+    it "validates keys don't contain invalid chars" $ do
+      f ["goodKey"] `shouldSatisfy` isRight
+      f ["bad key"] `shouldSatisfy` isLeft
+
   describe "flatten" $ do
     it "no-ops static" $ do
       flatten (Static "xyz") `shouldBe` Static "xyz"

--- a/test/Intlc/EndToEndSpec.hs
+++ b/test/Intlc/EndToEndSpec.hs
@@ -4,7 +4,7 @@ import           Data.ByteString.Lazy (ByteString)
 import qualified Data.Text            as T
 import           Intlc.Compiler       (compileDataset)
 import           Intlc.Core           (Locale (Locale))
-import           Intlc.Parser         (ParseFailure (..), parseDataset)
+import           Intlc.Parser         (parseDataset)
 import           Prelude              hiding (ByteString)
 import           System.FilePath      ((<.>), (</>))
 import           Test.Hspec
@@ -12,7 +12,7 @@ import           Test.Hspec.Golden    (Golden (..), defaultGolden)
 import           Text.RawString.QQ    (r)
 
 parseAndCompileDataset :: ByteString -> Either (NonEmpty Text) Text
-parseAndCompileDataset = fmap (compileDataset (Locale "en-US")) . first (pure . show) . parseDataset
+parseAndCompileDataset = compileDataset (Locale "en-US") <=< first (pure . show) . parseDataset
 
 golden :: String -> ByteString -> Golden String
 golden name in' = baseCfg
@@ -35,10 +35,6 @@ spec :: Spec
 spec = describe "end-to-end" $ do
   it "example message" $ do
     golden "example" [r|{ "title": { "message": "Unsplash" }, "greeting": { "message": "Hello <bold>{name}</bold>, {age, number}!", "backend": "ts" } }|]
-
-  it "validates that keys are alphanumeric" $ do
-    parseDataset [r|{ "x bad key": { "message": "foo" }, "good_Key": { "message": "bar" }, "y-bad-key": { "message": "baz" }, "z_bad_key123": { "message": "biz" } }|] `shouldBe`
-      Left (InvalidKeys $ "x bad key" :| ["y-bad-key", "z_bad_key123"])
 
   it "compiles valid JS module format given empty input" $ do
     [r|{}|]


### PR DESCRIPTION
This PR principally fixes #81, however it also checks that keys aren't empty, and improves extensibility for any future backends that have different identifier rules than JavaScript/TypeScript.

Example compile output:

```
Invalid keys:
	[Empty identifier found.]
	bad key 1: invalid identifier.
	delete: reserved word.
```