### PR TITLE
Fix select parsing # plural interpolations

### DIFF
--- a/lib/Intlc/Parser.hs
+++ b/lib/Intlc/Parser.hs
@@ -149,9 +149,11 @@ interp = do
           , Number <$ string "number"
           , Date <$> (string "date" *> sep *> dateTimeFmt)
           , Time <$> (string "time" *> sep *> dateTimeFmt)
-          , Plural <$> withPluralCtx n (string "plural" *> sep *> cardinalPluralCases)
-          , Plural <$> withPluralCtx n (string "selectordinal" *> sep *> ordinalPluralCases)
-          , uncurry Select <$> (string "select" *> sep *> selectCases)
+          , try $ uncurry Select <$> (string "select" *> sep *> selectCases)
+          , Plural <$> withPluralCtx n (
+                  string "plural" *> sep *> cardinalPluralCases
+              <|> string "selectordinal" *> sep *> ordinalPluralCases
+            )
           ]
         withPluralCtx n p = pushPluralCtx n *> p <* popPluralCtx
         pushPluralCtx = modify . pushPluralArgName

--- a/test/Intlc/ParserSpec.hs
+++ b/test/Intlc/ParserSpec.hs
@@ -32,6 +32,9 @@ spec = describe "parser" $ do
     describe "plural hash" $ do
       it "parses as plaintext outside of plurals" $ do
         parse msg "#" `shouldParse` Static "#"
+        parse msg "{x, select, y {#}}" `shouldParse`
+          (Dynamic . pure . Interpolation . Arg "x" $
+            Select (pure $ SelectCase "y" (pure $ Plaintext "#")) Nothing)
 
       it "parses as arg inside shallow plural" $ do
         let n = pure . Interpolation $ Arg "n" Number


### PR DESCRIPTION
Fixes #79. The issue mentioned either just fixing the parse or properly supporting `#` in `select`, which would diverge from ICU spec. This PR does the former.

See commit for details.