### PR TITLE
Add initial support for number skeletons

### DIFF
--- a/lib/Intlc/Backend/ICU/Compiler.hs
+++ b/lib/Intlc/Backend/ICU/Compiler.hs
@@ -25,16 +25,29 @@ token (Plaintext x)     = x
 token (Interpolation x) = arg x
 
 arg :: Arg -> Text
-arg (Arg n Bool { trueCase, falseCase }) = "{" <> n <> ", boolean, true {" <> stream trueCase <> "} false {" <> stream falseCase <> "}}"
+arg (Arg n Bool { trueCase, falseCase }) = "{" <> n <> ", boolean, true {" <> stream trueCase   <> "} false {" <> stream falseCase <> "}}"
 arg (Arg n String)                       = "{" <> n <> "}"
-arg (Arg n Number)                       = "{" <> n <> ", number}"
-arg (Arg n (Date fmt))                   = "{" <> n <> ", date, "          <> dateTimeFmt fmt  <> "}"
-arg (Arg n (Time fmt))                   = "{" <> n <> ", time, "          <> dateTimeFmt fmt  <> "}"
-arg (Arg n (Plural (Cardinal p)))        = "{" <> n <> ", plural, "        <> cardinalPlural p <> "}"
-arg (Arg n (Plural (Ordinal p)))         = "{" <> n <> ", selectordinal, " <> ordinalPlural p  <> "}"
+arg (Arg n (Number Nothing))             = "{" <> n <> ", number}"
+arg (Arg n (Number (Just sk)))           = "{" <> n <> ", number, ::"      <> numberSkeleton sk <> "}"
+arg (Arg n (Date fmt))                   = "{" <> n <> ", date, "          <> dateTimeFmt fmt   <> "}"
+arg (Arg n (Time fmt))                   = "{" <> n <> ", time, "          <> dateTimeFmt fmt   <> "}"
+arg (Arg n (Plural (Cardinal p)))        = "{" <> n <> ", plural, "        <> cardinalPlural p  <> "}"
+arg (Arg n (Plural (Ordinal p)))         = "{" <> n <> ", selectordinal, " <> ordinalPlural p   <> "}"
 arg (Arg _ PluralRef)                    = "#"
-arg (Arg n (Select xs y))                = "{" <> n <> ", select, "        <> select xs y      <> "}"
-arg (Arg n (Callback xs))                = "<" <> n <> ">"                 <> stream xs        <> "</" <> n <> ">"
+arg (Arg n (Select xs y))                = "{" <> n <> ", select, "        <> select xs y       <> "}"
+arg (Arg n (Callback xs))                = "<" <> n <> ">"                 <> stream xs         <> "</" <> n <> ">"
+
+numberSkeleton :: NumberSkeleton -> Text
+numberSkeleton (NumberSkeleton x) = case x of
+  Currency code -> "currency/" <> currencyCode code
+  Measure unit  -> "unit/" <> numberMeasureUnit unit
+  Percent       -> "percent"
+
+currencyCode :: CurrencyCode -> Text
+currencyCode = show
+
+numberMeasureUnit :: NumberMeasureUnit -> Text
+numberMeasureUnit Megabyte = "megabyte"
 
 dateTimeFmt :: DateTimeFmt -> Text
 dateTimeFmt Short  = "short"

--- a/lib/Intlc/Backend/JavaScript/Language.hs
+++ b/lib/Intlc/Backend/JavaScript/Language.hs
@@ -17,7 +17,7 @@ data Stmt = Stmt Text (NonEmpty Expr)
 data Expr
   = TPrint Text
   | TStr Ref
-  | TNum Ref
+  | TNum Ref (Maybe ICU.NumberSkeleton)
   | TDate Ref ICU.DateTimeFmt
   | TTime Ref ICU.DateTimeFmt
   | TApply Ref [Expr]
@@ -64,11 +64,11 @@ fromArg (ICU.Arg nraw t) =
       y <- fromBoolCase False falseCase
       pure . TMatch . Match n LitCond . LitMatchRet $ x :| [y]
     ICU.String             -> pure $ TStr n
-    ICU.Number             -> pure $ TNum n
+    ICU.Number x           -> pure $ TNum n x
     ICU.Date x             -> pure $ TDate n x
     ICU.Time x             -> pure $ TTime n x
     ICU.Plural x           -> TMatch <$> fromPlural n x
-    ICU.PluralRef          -> pure $ TNum n
+    ICU.PluralRef          -> pure $ TNum n Nothing
     ICU.Select cs (Just w) -> ((TMatch . Match n LitCond) .) . NonLitMatchRet <$> (fromSelectCase `mapM` cs) <*> fromSelectWildcard w
     ICU.Select cs Nothing  -> TMatch . Match n LitCond . LitMatchRet <$> (fromSelectCase `mapM` cs)
     ICU.Callback xs        -> TApply n <$> (fromToken `mapM` xs)

--- a/lib/Intlc/Backend/TypeScript/Language.hs
+++ b/lib/Intlc/Backend/TypeScript/Language.hs
@@ -51,7 +51,7 @@ fromToken (ICU.Interpolation x) = fromArg x
 fromArg :: ICU.Arg -> UncollatedArgs
 fromArg (ICU.Arg n (ICU.Bool xs ys))   = (n, TBool) : (fromToken =<< xs) <> (fromToken =<< ys)
 fromArg (ICU.Arg n ICU.String)         = pure (n, TStr)
-fromArg (ICU.Arg n ICU.Number)         = pure (n, TNum)
+fromArg (ICU.Arg n ICU.Number {})      = pure (n, TNum)
 fromArg (ICU.Arg n ICU.Date {})        = pure (n, TDate)
 fromArg (ICU.Arg n ICU.Time {})        = pure (n, TDate)
 fromArg (ICU.Arg n (ICU.Plural x))     = fromPlural n x

--- a/lib/Intlc/ICU.hs
+++ b/lib/Intlc/ICU.hs
@@ -35,7 +35,7 @@ data Arg = Arg Text Type
 data Type
   = Bool { trueCase :: Stream, falseCase :: Stream }
   | String
-  | Number
+  | Number (Maybe NumberSkeleton)
   | Date DateTimeFmt
   | Time DateTimeFmt
   | Plural Plural
@@ -44,6 +44,35 @@ data Type
   | PluralRef
   | Select (NonEmpty SelectCase) (Maybe SelectWildcard)
   | Callback Stream
+  deriving (Show, Eq)
+
+-- Only a small subset of the ICU number skeleton spec is currently
+-- implemented. This can be extended at any time.
+data NumberSkeleton = NumberSkeleton NumberToken
+  deriving (Show, Eq)
+
+data NumberToken
+  = Currency CurrencyCode
+  | Measure NumberMeasureUnit
+  | Percent
+  deriving (Show, Eq)
+
+-- For now we're listing these explicitly so that we can check for typos in the
+-- parser. At some point we may need to give up and replace this with unsafe
+-- plaintext.
+data CurrencyCode
+  = USD
+  | EUR
+  | GBP
+  | CNY
+  | JPY
+  | CAD
+  deriving (Show, Read, Eq)
+
+-- Refer to this list for units supported in JavaScript:
+--   https://tc39.es/proposal-unified-intl-numberformat/section6/locales-currencies-tz_proposed_out.html#sec-issanctionedsimpleunitidentifier
+data NumberMeasureUnit
+  = Megabyte
   deriving (Show, Eq)
 
 data DateTimeFmt

--- a/test/Intlc/Backend/TypeScriptSpec.hs
+++ b/test/Intlc/Backend/TypeScriptSpec.hs
@@ -42,7 +42,7 @@ spec = describe "TypeScript compiler" $ do
               )
             )))
           , ICU.Plaintext ". Regardless, the magic number is most certainly "
-          , ICU.Interpolation (ICU.Arg "magicNumber" ICU.Number)
+          , ICU.Interpolation (ICU.Arg "magicNumber" (ICU.Number Nothing))
           , ICU.Plaintext "! The date is "
           , ICU.Interpolation (ICU.Arg "todayDate" (ICU.Date ICU.Short))
           , ICU.Plaintext ", and the time is "
@@ -115,7 +115,7 @@ spec = describe "TypeScript compiler" $ do
       let x = ICU.Plural . ICU.Ordinal $ ICU.OrdinalPlural
                 [ICU.PluralCase (ICU.PluralExact "42") [ICU.Interpolation $ ICU.Arg "foo" (ICU.Date ICU.Short)]]
                 (pure $ ICU.PluralCase ICU.Few [ICU.Interpolation $ ICU.Arg "bar" ICU.String])
-                (ICU.PluralWildcard [ICU.Interpolation $ ICU.Arg "baz" ICU.Number])
+                (ICU.PluralWildcard [ICU.Interpolation $ ICU.Arg "baz" (ICU.Number Nothing)])
       let ys =
               [ ("x", pure TS.TNum)
               , ("foo", pure TS.TDate)
@@ -127,7 +127,7 @@ spec = describe "TypeScript compiler" $ do
     it "in boolean" $ do
       let x = ICU.Bool
                 [ICU.Interpolation $ ICU.Arg "y" ICU.String]
-                [ICU.Interpolation $ ICU.Arg "z" ICU.Number]
+                [ICU.Interpolation $ ICU.Arg "z" (ICU.Number Nothing)]
       let ys =
               [ ("x", pure TS.TBool)
               , ("y", pure TS.TStr)

--- a/test/Intlc/CompilerSpec.hs
+++ b/test/Intlc/CompilerSpec.hs
@@ -56,7 +56,7 @@ spec = describe "compiler" $ do
             [ Interpolation . Arg "count" . Plural . Cardinal $ RulePlural
               (pure $ PluralCase One [Plaintext "a dog"])
               (PluralWildcard
-                [ Interpolation $ Arg "count" Number
+                [ Interpolation $ Arg "count" (Number Nothing)
                 , Plaintext " dogs, the newest of which is "
                 , Interpolation . Arg "name" $ Select
                   (pure $ SelectCase "hodor" [Plaintext "Hodor"])
@@ -72,13 +72,13 @@ spec = describe "compiler" $ do
                 [ Interpolation . Arg "name" $ Select
                   (pure $ SelectCase "hodor"
                     [ Plaintext "I have "
-                    , Interpolation $ Arg "count" Number
+                    , Interpolation $ Arg "count" (Number Nothing)
                     , Plaintext " dogs, the newest of which is Hodor!"
                     ]
                   )
                   (pure $ SelectWildcard
                     [ Plaintext "I have "
-                    , Interpolation $ Arg "count" Number
+                    , Interpolation $ Arg "count" (Number Nothing)
                     , Plaintext " dogs, the newest of which is unknown!"
                     ]
                   )

--- a/test/Intlc/EndToEndSpec.hs
+++ b/test/Intlc/EndToEndSpec.hs
@@ -52,6 +52,10 @@ spec = describe "end-to-end" $ do
     [r|{ "f": { "message": "{x, boolean, true {y} false {z}}" } }|]
       =*= "export const f: (x: { x: boolean }) => string = x => `${(() => { switch (x.x) { case true: return `y`; case false: return `z`; } })()}`"
 
+  it "compiles numbers" $ do
+    [r|{ "f": { "message": "{n, number} {mb, number, ::unit/megabyte}" } }|]
+      =*= "export const f: (x: { mb: number; n: number }) => string = x => `${new Intl.NumberFormat('en-US').format(x.n)} ${new Intl.NumberFormat('en-US', { style: 'unit', unit: 'megabyte' }).format(x.mb)}`"
+
   it "compiles plurals" $ do
     [r|{ "prop": { "message": "Age: {age, plural, =0 {newborn called {name}} =42 {magical} other {boring #}}", "backend": "ts" } }|]
       =*= "export const prop: (x: { age: number; name: string }) => string = x => `Age: ${(() => { switch (x.age) { case 0: return `newborn called ${x.name}`; case 42: return `magical`; default: return `boring ${new Intl.NumberFormat('en-US').format(x.age)}`; } })()}`"

--- a/test/Intlc/ParserSpec.hs
+++ b/test/Intlc/ParserSpec.hs
@@ -6,13 +6,16 @@ import           Prelude               hiding (ByteString)
 import           Test.Hspec
 import           Test.Hspec.Megaparsec hiding (initialState)
 import           Text.Megaparsec       (ParseErrorBundle, runParser)
-import           Text.Megaparsec.Error (ErrorFancy (ErrorCustom))
+import           Text.Megaparsec.Error (ErrorFancy (ErrorCustom), ParseError)
 
 parseWith :: ParserState -> Parser a -> Text -> Either (ParseErrorBundle Text MessageParseErr) a
 parseWith s p = runParser (runReaderT p s) "test"
 
 parse :: Parser a -> Text -> Either (ParseErrorBundle Text MessageParseErr) a
 parse = parseWith initialState
+
+e :: Int -> e -> ParseError s e
+e i = errFancy i . fancy . ErrorCustom
 
 spec :: Spec
 spec = describe "parser" $ do
@@ -133,8 +136,6 @@ spec = describe "parser" $ do
       parse callback `shouldFailOn` "<hello></there>"
 
     it "reports friendly error for bad closing tag" $ do
-      let e i = errFancy i . fancy . ErrorCustom
-
       parse callback "<hello> there" `shouldFailWith` e 1 (NoClosingCallbackTag "hello")
       parse callback "<hello> </there>" `shouldFailWith` e 10 (BadClosingCallbackTag "hello" "there")
 


### PR DESCRIPTION
Closes #20.

The following are supported as of this PR:

```
{n, number, ::percent}
{n, number, ::currency/USD}
{n, number, ::unit/megabyte}
```

"megabyte" is the only supported unit at present. It's a long [list](https://tc39.es/proposal-unified-intl-numberformat/section6/locales-currencies-tz_proposed_out.html#sec-issanctionedsimpleunitidentifier) and that's a known use case for Unsplash web, but further units would be very simple to add.

The top six globally-traded currencies are supported. This PR takes the view that on balance a whitelist of currencies is, for now at least, the lesser evil, weighing between maintainability and safety.

`::percent` compiles to an `Intl.NumberFormat` constructor options object of `{ style: 'percent' }`, which formats as a ratio (`1` as `100%`). We could alternatively compile to `{ style: 'unit', unit: 'percent' }` which'd format `1` as `1%`.

Further ICU number skeleton features can be supported upon a use case appearing (or a feature request for any onlookers!).