### PR TITLE
Report all dataset parse failures

### DIFF
--- a/intlc.cabal
+++ b/intlc.cabal
@@ -22,6 +22,7 @@ common common
     , optics               ^>=0.4
     , relude               ^>=1.0
     , text                 ^>=1.2
+    , validation           ^>=1.1
   mixins:
       base hiding (Prelude)
     , relude (Relude as Prelude)

--- a/intlc.cabal
+++ b/intlc.cabal
@@ -25,6 +25,7 @@ common common
   mixins:
       base hiding (Prelude)
     , relude (Relude as Prelude)
+    , relude
 
 executable intlc
   import:                  common

--- a/lib/Intlc/Parser.hs
+++ b/lib/Intlc/Parser.hs
@@ -23,6 +23,8 @@ import           Text.Megaparsec.Char
 import qualified Text.Megaparsec.Char.Lexer               as L
 import           Text.Megaparsec.Error.Builder
 
+type ParseErr = ParseErrorBundle Text MessageParseErr
+
 data ParseFailure
   = FailedJsonParse
   | FailedMessageParse ParseErr
@@ -53,8 +55,6 @@ parseTranslationFor :: Text -> UnparsedTranslation -> Either ParseErr Translatio
 parseTranslationFor name (UnparsedTranslation umsg be md) = do
   msg' <- runParser (runReaderT msg initialState) (T.unpack name) umsg
   pure $ Translation msg' be md
-
-type ParseErr = ParseErrorBundle Text MessageParseErr
 
 data ParserState = ParserState
   { pluralCtxName :: Maybe Text

--- a/lib/Intlc/Parser.hs
+++ b/lib/Intlc/Parser.hs
@@ -12,6 +12,8 @@ import           Data.Aeson                               (decode)
 import           Data.ByteString.Lazy                     (ByteString)
 import qualified Data.Map                                 as M
 import qualified Data.Text                                as T
+import           Data.Validation                          (toEither,
+                                                           validationNel)
 import           Data.Void                                ()
 import           Intlc.Core
 import           Intlc.ICU
@@ -49,7 +51,7 @@ printErr (FailedDatasetParse es) = intercalate "\n" . toList . fmap errorBundleP
 parseDataset :: ByteString -> Either ParseFailure (Dataset Translation)
 parseDataset = parse' <=< decode'
   where decode' = maybeToRight FailedJsonParse . decode
-        parse' = M.traverseWithKey ((first (FailedDatasetParse . pure) .) . parseTranslationFor)
+        parse' = toEither . first FailedDatasetParse . M.traverseWithKey ((validationNel .) . parseTranslationFor)
 
 parseTranslationFor :: Text -> UnparsedTranslation -> Either ParseErr Translation
 parseTranslationFor name (UnparsedTranslation umsg be md) = do


### PR DESCRIPTION
Closes #113, though I'd still like to improve the story around line numbers and such.

Given:

```json
{
  "f": {
    "message": "{x, bad1}"
  },
  "g": {
    "message": "{y, bad2}"
  }
}
```

Before:

```console
$ intlc compile <file> -l <locale>
f:1:5:
  |
1 | {x, bad1}
  |     ^^^^^
unexpected "bad1}"
expecting "boolean", "date", "number", "plural", "select", "selectordinal", "time", or white space
```

After:

```console
$ intlc compile <file> -l <locale>
f:1:5:
  |
1 | {x, bad1}
  |     ^^^^^
unexpected "bad1}"
expecting "boolean", "date", "number", "plural", "select", "selectordinal", "time", or white space

g:1:5:
  |
1 | {y, bad2}
  |     ^^^^^
unexpected "bad2}"
expecting "boolean", "date", "number", "plural", "select", "selectordinal", "time", or white space
```