### PR TITLE
Custom JSON parsing

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -47,7 +47,7 @@ The ICU message parser is a [recursive descent parser](https://en.wikipedia.org/
 
 For example, given an ICU message `hello <bold>{name}</bold>`, we’d first try parsing for an interpolation or tag, and failing that would parse plaintext, which we’d do until we encountered a reason to stop, in this case the tag opening character. We’ve stored "hello " as plaintext and will now continue along, this time succeeding in parsing the tag. We’ll now recursively parse inside the bounds of the tag, reusing the same top-level parser we were just using, this time parsing an interpolation. Having done this we’ve _consumed_ the entire input string and have successfully parsed a recursive list of nodes making up our [AST](https://en.wikipedia.org/wiki/Abstract_syntax_tree).
 
-JSON parsing is offloaded to [aeson](https://hackage.haskell.org/package/aeson).
+JSON parsing is partially offloaded to [aeson](https://hackage.haskell.org/package/aeson).
 
 ### Compilation
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Translation files should be encoded as JSON and might look something like this:
 {
   "welcome": {
     "message": "Hello {name}",
+    "description": "Welcome message",
     "backend": "ts"
   }
 }

--- a/cli/Main.hs
+++ b/cli/Main.hs
@@ -16,5 +16,4 @@ main = getOpts >>= \case
         compilerDie = die . T.unpack . ("Invalid keys:\n" <>) . T.intercalate "\n" . fmap ("\t" <>) . toList
 
 getParsed :: FilePath -> IO (Either ParseFailure (Dataset Translation))
-getParsed = fmap parseDataset . readFileLBS
-
+getParsed x = parseDataset x <$> readFileText x

--- a/cli/Main.hs
+++ b/cli/Main.hs
@@ -4,7 +4,7 @@ import           CLI            (Opts (..), getOpts)
 import qualified Data.Text      as T
 import           Intlc.Compiler (compileDataset, compileFlattened)
 import           Intlc.Core
-import           Intlc.Parser   (ParseFailure, parseDataset, printErr)
+import           Intlc.Parser.ICU   (ParseFailure, parseDataset, printErr)
 import           Prelude
 
 main :: IO ()

--- a/cli/Main.hs
+++ b/cli/Main.hs
@@ -4,7 +4,7 @@ import           CLI            (Opts (..), getOpts)
 import qualified Data.Text      as T
 import           Intlc.Compiler (compileDataset, compileFlattened)
 import           Intlc.Core
-import           Intlc.Parser.ICU   (ParseFailure, parseDataset, printErr)
+import           Intlc.Parser   (ParseFailure, parseDataset, printErr)
 import           Prelude
 
 main :: IO ()

--- a/intlc.cabal
+++ b/intlc.cabal
@@ -54,7 +54,7 @@ library
     Intlc.Backend.TypeScript.Compiler
     Intlc.Core
     Intlc.ICU
-    Intlc.Parser
+    Intlc.Parser.ICU
     Utils
 
 test-suite test-intlc
@@ -78,4 +78,4 @@ test-suite test-intlc
     Intlc.Backend.TypeScriptSpec
     Intlc.CompilerSpec
     Intlc.EndToEndSpec
-    Intlc.ParserSpec
+    Intlc.Parser.ICUSpec

--- a/intlc.cabal
+++ b/intlc.cabal
@@ -55,6 +55,7 @@ library
     Intlc.Core
     Intlc.ICU
     Intlc.Parser
+    Intlc.Parser.JSON
     Intlc.Parser.ICU
     Utils
 
@@ -79,4 +80,5 @@ test-suite test-intlc
     Intlc.Backend.TypeScriptSpec
     Intlc.CompilerSpec
     Intlc.EndToEndSpec
+    Intlc.Parser.JSONSpec
     Intlc.Parser.ICUSpec

--- a/intlc.cabal
+++ b/intlc.cabal
@@ -54,6 +54,7 @@ library
     Intlc.Backend.TypeScript.Compiler
     Intlc.Core
     Intlc.ICU
+    Intlc.Parser
     Intlc.Parser.ICU
     Utils
 

--- a/lib/Intlc/Core.hs
+++ b/lib/Intlc/Core.hs
@@ -2,11 +2,8 @@
 
 module Intlc.Core where
 
-import           Data.Aeson          (FromJSON (..), ToJSON (toEncoding),
-                                      withObject, withText, (.!=), (.:), (.:?),
-                                      (.=))
+import           Data.Aeson          (ToJSON (toEncoding), (.=))
 import           Data.Aeson.Encoding (pairs, string)
-import qualified Data.Text           as T
 import           Intlc.ICU           (Message)
 import           Prelude
 
@@ -22,12 +19,6 @@ data Backend
   | TypeScriptReact
   deriving (Show, Eq, Generic)
 
-instance FromJSON Backend where
-  parseJSON = withText "Backend" decode
-    where decode "ts"  = pure TypeScript
-          decode "tsx" = pure TypeScriptReact
-          decode x     = fail $ "Unknown backend: " <> T.unpack x
-
 instance ToJSON Backend where
   toEncoding TypeScript      = string "ts"
   toEncoding TypeScriptReact = string "tsx"
@@ -38,13 +29,6 @@ data UnparsedTranslation = UnparsedTranslation
   , umdesc   :: Maybe Text
   }
   deriving (Show, Eq, Generic)
-
-instance FromJSON UnparsedTranslation where
-  parseJSON = withObject "UnparsedTranslation" decode
-    where decode x = UnparsedTranslation
-            <$> x .: "message"
-            <*> x .:? "backend" .!= TypeScript
-            <*> x .:? "description"
 
 instance ToJSON UnparsedTranslation where
   toEncoding (UnparsedTranslation msg be md) = pairs $

--- a/lib/Intlc/Parser.hs
+++ b/lib/Intlc/Parser.hs
@@ -1,0 +1,33 @@
+module Intlc.Parser where
+
+import           Data.Aeson            (decode)
+import           Data.ByteString.Lazy  (ByteString)
+import qualified Data.Map              as M
+import qualified Data.Text             as T
+import           Data.Validation       (toEither, validationNel)
+import           Intlc.Core
+import           Intlc.Parser.ICU      (MessageParseErr, initialState, msg)
+import           Prelude               hiding (ByteString)
+import           Text.Megaparsec       (runParser)
+import           Text.Megaparsec.Error
+
+parseDataset :: ByteString -> Either ParseFailure (Dataset Translation)
+parseDataset = parse' <=< decode'
+  where decode' = maybeToRight FailedJsonParse . decode
+        parse' = toEither . first FailedDatasetParse . M.traverseWithKey ((validationNel .) . parseTranslationFor)
+
+parseTranslationFor :: Text -> UnparsedTranslation -> Either ParseErr Translation
+parseTranslationFor name (UnparsedTranslation umsg be md) = do
+  msg' <- runParser (runReaderT msg initialState) (T.unpack name) umsg
+  pure $ Translation msg' be md
+
+type ParseErr = ParseErrorBundle Text MessageParseErr
+
+data ParseFailure
+  = FailedJsonParse
+  | FailedDatasetParse (NonEmpty ParseErr)
+  deriving (Show, Eq)
+
+printErr :: ParseFailure -> String
+printErr FailedJsonParse         = "Failed to parse JSON"
+printErr (FailedDatasetParse es) = intercalate "\n" . toList . fmap errorBundlePretty $ es

--- a/lib/Intlc/Parser/ICU.hs
+++ b/lib/Intlc/Parser/ICU.hs
@@ -5,7 +5,7 @@
 {-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
 {-# HLINT ignore "Use newtype instead of data" #-}
 
-module Intlc.Parser where
+module Intlc.Parser.ICU where
 
 import qualified Control.Applicative.Combinators.NonEmpty as NE
 import           Data.Aeson                               (decode)

--- a/lib/Intlc/Parser/ICU.hs
+++ b/lib/Intlc/Parser/ICU.hs
@@ -43,11 +43,14 @@ type Parser = ReaderT ParserState (Parsec MessageParseErr Text)
 ident :: Parser Text
 ident = T.pack <$> some letterChar
 
+toMsg :: Stream -> Message
+toMsg = mergePlaintext >>> \case
+  []            -> Static ""
+  [Plaintext x] -> Static x
+  (x:xs)        -> Dynamic (x :| xs)
+
 msg :: Parser Message
-msg = f . mergePlaintext <$> manyTill token eof
-  where f []            = Static ""
-        f [Plaintext x] = Static x
-        f (x:xs)        = Dynamic (x :| xs)
+msg = toMsg <$> manyTill token eof
 
 token :: Parser Token
 token = choice

--- a/lib/Intlc/Parser/ICU.hs
+++ b/lib/Intlc/Parser/ICU.hs
@@ -8,14 +8,8 @@
 module Intlc.Parser.ICU where
 
 import qualified Control.Applicative.Combinators.NonEmpty as NE
-import           Data.Aeson                               (decode)
-import           Data.ByteString.Lazy                     (ByteString)
-import qualified Data.Map                                 as M
 import qualified Data.Text                                as T
-import           Data.Validation                          (toEither,
-                                                           validationNel)
 import           Data.Void                                ()
-import           Intlc.Core
 import           Intlc.ICU
 import           Prelude                                  hiding (ByteString)
 import           Text.Megaparsec                          hiding (State, Stream,
@@ -24,13 +18,6 @@ import           Text.Megaparsec                          hiding (State, Stream,
 import           Text.Megaparsec.Char
 import qualified Text.Megaparsec.Char.Lexer               as L
 import           Text.Megaparsec.Error.Builder
-
-type ParseErr = ParseErrorBundle Text MessageParseErr
-
-data ParseFailure
-  = FailedJsonParse
-  | FailedDatasetParse (NonEmpty ParseErr)
-  deriving (Show, Eq)
 
 data MessageParseErr
   = NoClosingCallbackTag Text
@@ -43,20 +30,6 @@ instance ShowErrorComponent MessageParseErr where
 
 failingWith :: MonadParsec e s m => Int -> e -> m a
 pos `failingWith` e = parseError . errFancy pos . fancy . ErrorCustom $ e
-
-printErr :: ParseFailure -> String
-printErr FailedJsonParse         = "Failed to parse JSON"
-printErr (FailedDatasetParse es) = intercalate "\n" . toList . fmap errorBundlePretty $ es
-
-parseDataset :: ByteString -> Either ParseFailure (Dataset Translation)
-parseDataset = parse' <=< decode'
-  where decode' = maybeToRight FailedJsonParse . decode
-        parse' = toEither . first FailedDatasetParse . M.traverseWithKey ((validationNel .) . parseTranslationFor)
-
-parseTranslationFor :: Text -> UnparsedTranslation -> Either ParseErr Translation
-parseTranslationFor name (UnparsedTranslation umsg be md) = do
-  msg' <- runParser (runReaderT msg initialState) (T.unpack name) umsg
-  pure $ Translation msg' be md
 
 data ParserState = ParserState
   { pluralCtxName :: Maybe Text

--- a/lib/Intlc/Parser/JSON.hs
+++ b/lib/Intlc/Parser/JSON.hs
@@ -1,0 +1,78 @@
+-- An in-house JSON parser specialised to our needs, piggybacking off of the
+-- sibling ICU parser. Allows interop with our ICU parser and bypasses some
+-- Aeson limitations.
+--
+-- This module follows the following whitespace rules:
+--   * Consume all whitespace after tokens where possible.
+--   * Therefore, assume no whitespace before tokens.
+
+module Intlc.Parser.JSON where
+
+import           Control.Applicative.Permutations
+import qualified Data.Map                         as M
+import qualified Data.Text                        as T
+import           Data.Void                        ()
+import           Intlc.Core
+import qualified Intlc.ICU                        as ICU
+import           Intlc.Parser.ICU                 (MessageParseErr,
+                                                   initialState, toMsg, token)
+import           Prelude                          hiding (ByteString, null)
+import           Text.Megaparsec                  hiding (State, Stream, Token,
+                                                   many, some, token)
+import           Text.Megaparsec.Char
+import qualified Text.Megaparsec.Char.Lexer       as L
+
+type Parser = Parsec MessageParseErr Text
+
+dataset :: Parser (Dataset Translation)
+dataset = space *> objMap translation <* space <* eof
+
+-- It's important to use `toPermutationWithDefault` as opposed to standard
+-- parser combinators like `optional` so that `intercalateEffect` can do its
+-- magic.
+--
+-- Additionally, the consistent application of whitespace is extremely
+-- important, and the permutation appears to operate over the first parser, so
+-- be careful around any abstractions around the key double quotes.
+translation :: Parser Translation
+translation = obj $ intercalateEffect objSep $ Translation
+  <$> toPermutation                       (objPair' "message"     msg)
+  <*> toPermutationWithDefault TypeScript (objPair' "backend"     (backendp <|> TypeScript <$ null))
+  <*> toPermutationWithDefault Nothing    (objPair' "description" (Just <$> strLit <|> Nothing <$ null))
+
+msg :: Parser ICU.Message
+msg = toMsg <$> runReaderT (char '"' *> manyTill token (char '"')) initialState
+
+backendp :: Parser Backend
+backendp = choice
+  [ TypeScript      <$ string (dblqts "ts")
+  , TypeScriptReact <$ string (dblqts "tsx")
+  ]
+
+null :: Parser ()
+null = void $ string "null"
+
+strLit :: Parser Text
+strLit = (T.pack <$>) $ char '"' *> manyTill L.charLiteral (char '"')
+
+dblqtsp :: Parser a -> Parser a
+dblqtsp = between (char '"') (char '"')
+
+dblqts :: Text -> Text
+dblqts x = "\"" <> x <> "\""
+
+-- Parse a homogeneous object of arbitrary keys.
+objMap :: Parser a -> Parser (Map Text a)
+objMap v = fmap M.fromList . obj $ sepEndBy (objPair strLit v) objSep
+
+obj :: Parser a -> Parser a
+obj p = string "{" *> space *> p <* space <* string "}"
+
+objPair :: Parser Text -> Parser a -> Parser (Text, a)
+objPair k v = (,) <$> k <*> (space *> char ':' *> space *> v)
+
+objPair' :: Text -> Parser a -> Parser a
+objPair' k v = snd <$> objPair (string (dblqts k)) v
+
+objSep :: Parser ()
+objSep = void $ char ',' <* space

--- a/test/Intlc/EndToEndSpec.hs
+++ b/test/Intlc/EndToEndSpec.hs
@@ -4,7 +4,7 @@ import           Data.ByteString.Lazy (ByteString)
 import qualified Data.Text            as T
 import           Intlc.Compiler       (compileDataset)
 import           Intlc.Core           (Locale (Locale))
-import           Intlc.Parser         (parseDataset)
+import           Intlc.Parser.ICU         (parseDataset)
 import           Prelude              hiding (ByteString)
 import           System.FilePath      ((<.>), (</>))
 import           Test.Hspec

--- a/test/Intlc/EndToEndSpec.hs
+++ b/test/Intlc/EndToEndSpec.hs
@@ -4,7 +4,7 @@ import           Data.ByteString.Lazy (ByteString)
 import qualified Data.Text            as T
 import           Intlc.Compiler       (compileDataset)
 import           Intlc.Core           (Locale (Locale))
-import           Intlc.Parser.ICU         (parseDataset)
+import           Intlc.Parser         (parseDataset)
 import           Prelude              hiding (ByteString)
 import           System.FilePath      ((<.>), (</>))
 import           Test.Hspec

--- a/test/Intlc/EndToEndSpec.hs
+++ b/test/Intlc/EndToEndSpec.hs
@@ -1,20 +1,19 @@
 module Intlc.EndToEndSpec (spec) where
 
-import           Data.ByteString.Lazy (ByteString)
-import qualified Data.Text            as T
-import           Intlc.Compiler       (compileDataset)
-import           Intlc.Core           (Locale (Locale))
-import           Intlc.Parser         (parseDataset)
-import           Prelude              hiding (ByteString)
-import           System.FilePath      ((<.>), (</>))
+import qualified Data.Text         as T
+import           Intlc.Compiler    (compileDataset)
+import           Intlc.Core        (Locale (Locale))
+import           Intlc.Parser      (parseDataset)
+import           Prelude
+import           System.FilePath   ((<.>), (</>))
 import           Test.Hspec
-import           Test.Hspec.Golden    (Golden (..), defaultGolden)
-import           Text.RawString.QQ    (r)
+import           Test.Hspec.Golden (Golden (..), defaultGolden)
+import           Text.RawString.QQ (r)
 
-parseAndCompileDataset :: ByteString -> Either (NonEmpty Text) Text
-parseAndCompileDataset = compileDataset (Locale "en-US") <=< first (pure . show) . parseDataset
+parseAndCompileDataset :: Text -> Either (NonEmpty Text) Text
+parseAndCompileDataset = compileDataset (Locale "en-US") <=< first (pure . show) . parseDataset "test"
 
-golden :: String -> ByteString -> Golden String
+golden :: String -> Text -> Golden String
 golden name in' = baseCfg
   { goldenFile = goldenFile baseCfg <.> "ts"
   , actualFile = actualFile baseCfg <&> (<.> "ts")
@@ -25,7 +24,7 @@ golden name in' = baseCfg
         fromErrs (Right x) = x
         fromErrs (Left es) = T.intercalate "\n" . toList $ es
 
-(=*=) :: ByteString -> Text -> IO ()
+(=*=) :: Text -> Text -> IO ()
 x =*= y = parseAndCompileDataset x `shouldBe` Right y
 
 withReactImport :: Text -> Text

--- a/test/Intlc/Parser/ICUSpec.hs
+++ b/test/Intlc/Parser/ICUSpec.hs
@@ -1,7 +1,6 @@
 module Intlc.Parser.ICUSpec (spec) where
 
 import           Intlc.ICU
-import           Intlc.Parser
 import           Intlc.Parser.ICU
 import           Prelude               hiding (ByteString)
 import           Test.Hspec
@@ -16,7 +15,7 @@ parse :: Parser a -> Text -> Either (ParseErrorBundle Text MessageParseErr) a
 parse = parseWith initialState
 
 spec :: Spec
-spec = describe "parser" $ do
+spec = describe "ICU parser" $ do
   describe "message" $ do
     it "does not tolerate unclosed braces" $ do
       parse msg `shouldFailOn` "a { b"

--- a/test/Intlc/Parser/ICUSpec.hs
+++ b/test/Intlc/Parser/ICUSpec.hs
@@ -1,6 +1,7 @@
 module Intlc.Parser.ICUSpec (spec) where
 
 import           Intlc.ICU
+import           Intlc.Parser
 import           Intlc.Parser.ICU
 import           Prelude               hiding (ByteString)
 import           Test.Hspec

--- a/test/Intlc/Parser/ICUSpec.hs
+++ b/test/Intlc/Parser/ICUSpec.hs
@@ -1,7 +1,7 @@
-module Intlc.ParserSpec (spec) where
+module Intlc.Parser.ICUSpec (spec) where
 
 import           Intlc.ICU
-import           Intlc.Parser
+import           Intlc.Parser.ICU
 import           Prelude               hiding (ByteString)
 import           Test.Hspec
 import           Test.Hspec.Megaparsec hiding (initialState)

--- a/test/Intlc/Parser/JSONSpec.hs
+++ b/test/Intlc/Parser/JSONSpec.hs
@@ -1,0 +1,37 @@
+module Intlc.Parser.JSONSpec (spec) where
+
+import           Intlc.Core
+import           Intlc.Parser.ICU      (MessageParseErr)
+import           Intlc.Parser.JSON     (dataset)
+import           Prelude               hiding (ByteString)
+import           Test.Hspec
+import           Test.Hspec.Megaparsec hiding (initialState)
+import           Text.Megaparsec       (ParseErrorBundle, runParser)
+import           Text.RawString.QQ     (r)
+
+parse :: Text -> Either (ParseErrorBundle Text MessageParseErr) (Dataset Translation)
+parse = runParser dataset "test"
+
+succeedsOn :: Text -> Expectation
+succeedsOn = shouldSucceedOn parse
+
+spec :: Spec
+spec = describe "JSON parser" $ do
+  it "parses multiple translations" $ do
+    succeedsOn [r|{ "f": { "message": "{foo}" }, "g": { "message": "{bar}" } }|]
+
+  it "parses translation data keys in any order" $ do
+    succeedsOn [r|{ "f": { "message": "{foo}", "backend": "ts", "description": "bar" } }|]
+    succeedsOn [r|{ "f": { "message": "{foo}", "backend": "ts" } }|]
+    succeedsOn [r|{ "f": { "message": "{foo}", "description": "bar", "backend": "ts" } }|]
+    succeedsOn [r|{ "f": { "message": "{foo}", "description": "bar" } }|]
+    succeedsOn [r|{ "f": { "backend": "ts", "message": "{foo}", "description": "bar" } }|]
+    succeedsOn [r|{ "f": { "backend": "ts", "message": "{foo}" } }|]
+    succeedsOn [r|{ "f": { "backend": "ts", "description": "bar", "message": "{foo}" } }|]
+    succeedsOn [r|{ "f": { "description": "bar", "message": "{foo}", "backend": "ts" } }|]
+    succeedsOn [r|{ "f": { "description": "bar", "message": "{foo}" } }|]
+    succeedsOn [r|{ "f": { "description": "bar", "backend": "ts", "message": "{foo}" } }|]
+
+  it "accepts null or absence for optional keys" $ do
+    succeedsOn [r|{ "f": { "message": "{foo}", "backend": null, "description": null } }|]
+    succeedsOn [r|{ "f": { "message": "{foo}" } }|]


### PR DESCRIPTION
Depends #114.

Whilst implementing our own JSON parser seems a bit wild, we don't really need a full JSON parser on account of our input following a fairly rigid schema. This is mirrored in the relative simplicity of the added parser.

The immediate value add of this PR is useful file and line information on reported errors.

Given via `intlc compile -l foo <file>`:

```json
{
  "f": {
    "message": "{x, bad1}"
  },
  "g": {
    "message": ""
  },
  "h": {
    "message": "{y, number} {z, bad2}"
  }
}
```

Before (includes #114's multi error support):

```
f:1:5:
  |
1 | {x, bad1}
  |     ^^^^^
unexpected "bad1}"
expecting "boolean", "date", "number", "plural", "select", "selectordinal", "time", or white space

h:1:17:
  |
1 | {y, number} {z, bad2}
  |                 ^^^^^
unexpected "bad2}"
expecting "boolean", "date", "number", "plural", "select", "selectordinal", "time", or white space
```

After:

```
x-msg.json:3:21:
  |
3 |     "message": "{x, bad1}"
  |                     ^^^^^^^
unexpected "bad1}"<newline>  },<newline> "
expecting "boolean", "date", "number", "plural", "select", "selectordinal", "time", or white space

x-msg.json:9:33:
  |
9 |     "message": "{y, number} {z, bad2}"
  |                                 ^^^^^^^
unexpected "bad2}"<newline>  }<newline>}<newline>"
expecting "boolean", "date", "number", "plural", "select", "selectordinal", "time", or white space
```

This also implicitly solves the Aeson decoder accepting and silently discarding bad keys, which could lead to mistakes like `"beckand": "ts"`. As of this PR you'll get a very clear error:

```
x-key.json:7:5:
  |
7 |     "beckand": "ts"
  |     ^
unexpected '"'
expecting ""backend"", ""description"", '}', or white space
```

Detaching ourselves from Aeson decoding suggests we could and should implement our own encoder, which is really just going to be another "compiler" in the spirit of those we already have. This would solve our inability to pretty print flattened JSON output.

I'd additionally like to slightly modify the error output to include an additional line or two of context so that the offending key is visible.