### PR TITLE
Add JSON compiler

### DIFF
--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -47,7 +47,7 @@ The ICU message parser is a [recursive descent parser](https://en.wikipedia.org/
 
 For example, given an ICU message `hello <bold>{name}</bold>`, we’d first try parsing for an interpolation or tag, and failing that would parse plaintext, which we’d do until we encountered a reason to stop, in this case the tag opening character. We’ve stored "hello " as plaintext and will now continue along, this time succeeding in parsing the tag. We’ll now recursively parse inside the bounds of the tag, reusing the same top-level parser we were just using, this time parsing an interpolation. Having done this we’ve _consumed_ the entire input string and have successfully parsed a recursive list of nodes making up our [AST](https://en.wikipedia.org/wiki/Abstract_syntax_tree).
 
-JSON parsing is handled internally for better interop with the ICU parser. JSON encoding is offloaded to [aeson](https://hackage.haskell.org/package/aeson).
+JSON parsing is handled internally for better interop with the ICU parser.
 
 ### Compilation
 

--- a/cli/Main.hs
+++ b/cli/Main.hs
@@ -11,7 +11,7 @@ import           Prelude
 main :: IO ()
 main = getOpts >>= \case
   Compile path loc -> tryCompile loc =<< getParsed path
-  Flatten path -> either parserDie (putLBSLn . compileFlattened) =<< getParsed path
+  Flatten path -> either parserDie (putTextLn . compileFlattened) =<< getParsed path
   where tryCompile l = either parserDie (either compilerDie putTextLn . compileDataset l)
         parserDie = die . printErr
         compilerDie = die . T.unpack . ("Invalid keys:\n" <>) . T.intercalate "\n" . fmap ("\t" <>) . toList

--- a/intlc.cabal
+++ b/intlc.cabal
@@ -8,6 +8,7 @@ common common
   default-language:        Haskell2010
   default-extensions:
     LambdaCase
+    NamedFieldPuns
     NoImplicitPrelude
     OverloadedStrings
     TupleSections

--- a/intlc.cabal
+++ b/intlc.cabal
@@ -43,13 +43,13 @@ library
   import:                  common
   hs-source-dirs:          lib/
   build-depends:
-      aeson                ^>=2.0
-    , parser-combinators   ^>=1.2
+      parser-combinators   ^>=1.2
     , megaparsec           ^>=9.0
   exposed-modules:
     Intlc.Compiler
     Intlc.Backend.JavaScript.Language
     Intlc.Backend.JavaScript.Compiler
+    Intlc.Backend.JSON.Compiler
     Intlc.Backend.ICU.Compiler
     Intlc.Backend.TypeScript.Language
     Intlc.Backend.TypeScript.Compiler

--- a/lib/Intlc/Backend/ICU/Compiler.hs
+++ b/lib/Intlc/Backend/ICU/Compiler.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE NamedFieldPuns #-}
-
 -- This module is essentially the inverse of the parsing we perform; it's
 -- semantically reversible in that respect if not precisely due to formatting,
 -- no preservation of the presence of defaults, etc.

--- a/lib/Intlc/Backend/JSON/Compiler.hs
+++ b/lib/Intlc/Backend/JSON/Compiler.hs
@@ -1,0 +1,41 @@
+module Intlc.Backend.JSON.Compiler where
+
+import qualified Data.Map                   as M
+import qualified Data.Text                  as T
+import           Intlc.Backend.ICU.Compiler (compileMsg)
+import           Intlc.Core
+import           Prelude
+
+dblqts :: Text -> Text
+dblqts v = "\"" <> v <> "\""
+
+strVal :: Text -> Text
+strVal = dblqts
+
+nullVal :: Text
+nullVal = "null"
+
+objKey :: Text -> Text
+objKey = dblqts
+
+objPair :: Text -> Text -> Text
+objPair k v = objKey k <> ":" <> v
+
+obj :: [(Text, Text)] -> Text
+obj xs = "{" <> ys <> "}"
+  where ys = T.intercalate "," . fmap (uncurry objPair) $ xs
+
+compileDataset :: Dataset Translation -> Text
+compileDataset = obj . M.toList . M.map translation
+
+translation :: Translation -> Text
+translation Translation { message, backend, mdesc } = obj . fromList $ ys
+  where ys =
+          [ ("message", strVal . compileMsg $ message)
+          , ("backend", backendVal)
+          , ("description", maybe nullVal strVal mdesc)
+          ]
+        backendVal = strVal $
+          case backend of
+             TypeScript      -> "ts"
+             TypeScriptReact -> "tsx"

--- a/lib/Intlc/Backend/JavaScript/Language.hs
+++ b/lib/Intlc/Backend/JavaScript/Language.hs
@@ -1,5 +1,3 @@
-{-# LANGUAGE NamedFieldPuns #-}
-
 module Intlc.Backend.JavaScript.Language where
 
 import           Intlc.Core (Locale)

--- a/lib/Intlc/Compiler.hs
+++ b/lib/Intlc/Compiler.hs
@@ -39,10 +39,10 @@ type ICUBool = (ICU.Stream, ICU.Stream)
 type ICUSelect = (NonEmpty ICU.SelectCase, Maybe ICU.SelectWildcard)
 
 compileFlattened :: Dataset Translation -> Text
-compileFlattened = JSON.compileDataset . flattenDataset
+compileFlattened = JSON.compileDataset . mapMsgs flatten
 
-flattenDataset :: Dataset Translation -> Dataset Translation
-flattenDataset = fmap $ \(Translation msg be md) -> Translation (flatten msg) be md
+mapMsgs :: (ICU.Message -> ICU.Message) -> Dataset Translation -> Dataset Translation
+mapMsgs f = fmap $ \x -> x { message = f (message x) }
 
 flatten :: ICU.Message -> ICU.Message
 flatten x@(ICU.Static _)      = x

--- a/lib/Intlc/Core.hs
+++ b/lib/Intlc/Core.hs
@@ -2,9 +2,7 @@
 
 module Intlc.Core where
 
-import           Data.Aeson          (ToJSON (toEncoding), (.=))
-import           Data.Aeson.Encoding (pairs, string)
-import           Intlc.ICU           (Message)
+import           Intlc.ICU (Message)
 import           Prelude
 
 -- Locales are too broad and too much of a moving target to validate, so this
@@ -19,22 +17,12 @@ data Backend
   | TypeScriptReact
   deriving (Show, Eq, Generic)
 
-instance ToJSON Backend where
-  toEncoding TypeScript      = string "ts"
-  toEncoding TypeScriptReact = string "tsx"
-
 data UnparsedTranslation = UnparsedTranslation
   { umessage :: UnparsedMessage
   , ubackend :: Backend
   , umdesc   :: Maybe Text
   }
   deriving (Show, Eq, Generic)
-
-instance ToJSON UnparsedTranslation where
-  toEncoding (UnparsedTranslation msg be md) = pairs $
-       "message"     .= msg
-    <> "backend"     .= be
-    <> "description" .= md
 
 data Translation = Translation
   { message :: Message

--- a/test/Intlc/CompilerSpec.hs
+++ b/test/Intlc/CompilerSpec.hs
@@ -1,11 +1,12 @@
 module Intlc.CompilerSpec (spec) where
 
-import           Intlc.Compiler (compileDataset, flatten)
-import           Intlc.Core     (Backend (TypeScript), Locale (Locale),
-                                 Translation (Translation))
+import           Intlc.Compiler    (compileDataset, compileFlattened, flatten)
+import           Intlc.Core        (Backend (..), Locale (Locale),
+                                    Translation (Translation))
 import           Intlc.ICU
-import           Prelude        hiding (one)
+import           Prelude           hiding (one)
 import           Test.Hspec
+import           Text.RawString.QQ (r)
 
 spec :: Spec
 spec = describe "compiler" $ do
@@ -22,7 +23,16 @@ spec = describe "compiler" $ do
     it "validates keys aren't empty" $ do
       f [""] `shouldSatisfy` isLeft
 
-  describe "flatten" $ do
+  describe "compile flattened dataset" $ do
+    it "flattens messages and outputs JSON" $ do
+      compileFlattened (fromList
+        [ ("x", Translation (Static "xfoo") TypeScript Nothing)
+        , ("z", Translation (Static "zfoo") TypeScriptReact (Just "zbar"))
+        , ("y", Translation (Dynamic $ Plaintext "yfoo " :| [Interpolation (Arg "ybar" String)]) TypeScript Nothing)
+        ])
+          `shouldBe` [r|{"x":{"message":"xfoo","backend":"ts","description":null},"y":{"message":"yfoo {ybar}","backend":"ts","description":null},"z":{"message":"zfoo","backend":"tsx","description":"zbar"}}|]
+
+  describe "flatten message" $ do
     it "no-ops static" $ do
       flatten (Static "xyz") `shouldBe` Static "xyz"
 


### PR DESCRIPTION
Aeson decoding of JSON was replaced in #115. This PR is the equivalent for encoding/compiling. This frees us from Aeson's constraints such as an inability to produce non-minified output, however that can be addressed in another PR. As with the parsing, the replacement code is very small as we only need to know how to compile a single type.