### PR TITLE
Slim the AST a bit

### DIFF
--- a/lib/Intlc/Backend/ICU/Compiler.hs
+++ b/lib/Intlc/Backend/ICU/Compiler.hs
@@ -14,8 +14,7 @@ import           Intlc.ICU
 import           Prelude
 
 compileMsg :: Message -> Text
-compileMsg (Static x)   = x
-compileMsg (Dynamic xs) = stream xs
+compileMsg (Message xs) = stream xs
 
 stream :: Foldable f => f Token -> Text
 stream = foldMap token

--- a/lib/Intlc/Backend/ICU/Compiler.hs
+++ b/lib/Intlc/Backend/ICU/Compiler.hs
@@ -11,7 +11,7 @@
 module Intlc.Backend.ICU.Compiler where
 
 import           Intlc.ICU
-import           Prelude
+import           Prelude   hiding (Type)
 
 compileMsg :: Message -> Text
 compileMsg (Message xs) = stream xs
@@ -20,20 +20,20 @@ stream :: Foldable f => f Token -> Text
 stream = foldMap token
 
 token :: Token -> Text
-token (Plaintext x)     = x
-token (Interpolation x) = arg x
+token (Plaintext x)       = x
+token (Interpolation x y) = interp x y
 
-arg :: Arg -> Text
-arg (Arg n Bool { trueCase, falseCase }) = "{" <> n <> ", boolean, true {" <> stream trueCase <> "} false {" <> stream falseCase <> "}}"
-arg (Arg n String)                       = "{" <> n <> "}"
-arg (Arg n Number)                       = "{" <> n <> ", number}"
-arg (Arg n (Date fmt))                   = "{" <> n <> ", date, "          <> dateTimeFmt fmt  <> "}"
-arg (Arg n (Time fmt))                   = "{" <> n <> ", time, "          <> dateTimeFmt fmt  <> "}"
-arg (Arg n (Plural (Cardinal p)))        = "{" <> n <> ", plural, "        <> cardinalPlural p <> "}"
-arg (Arg n (Plural (Ordinal p)))         = "{" <> n <> ", selectordinal, " <> ordinalPlural p  <> "}"
-arg (Arg _ PluralRef)                    = "#"
-arg (Arg n (Select xs y))                = "{" <> n <> ", select, "        <> select xs y      <> "}"
-arg (Arg n (Callback xs))                = "<" <> n <> ">"                 <> stream xs        <> "</" <> n <> ">"
+interp :: Text -> Type -> Text
+interp n Bool { trueCase, falseCase } = "{" <> n <> ", boolean, true {" <> stream trueCase <> "} false {" <> stream falseCase <> "}}"
+interp n String                       = "{" <> n <> "}"
+interp n Number                       = "{" <> n <> ", number}"
+interp n (Date fmt)                   = "{" <> n <> ", date, "          <> dateTimeFmt fmt  <> "}"
+interp n (Time fmt)                   = "{" <> n <> ", time, "          <> dateTimeFmt fmt  <> "}"
+interp n (Plural (Cardinal p))        = "{" <> n <> ", plural, "        <> cardinalPlural p <> "}"
+interp n (Plural (Ordinal p))         = "{" <> n <> ", selectordinal, " <> ordinalPlural p  <> "}"
+interp _ PluralRef                    = "#"
+interp n (Select xs y)                = "{" <> n <> ", select, "        <> select xs y      <> "}"
+interp n (Callback xs)                = "<" <> n <> ">"                 <> stream xs        <> "</" <> n <> ">"
 
 dateTimeFmt :: DateTimeFmt -> Text
 dateTimeFmt Short  = "short"

--- a/lib/Intlc/Backend/JavaScript/Language.hs
+++ b/lib/Intlc/Backend/JavaScript/Language.hs
@@ -11,7 +11,7 @@ type ASTCompiler = Reader Locale
 -- | A representation of the output we will be compiling. It's a little verbose
 -- split into these various sum types, but in doing so it's correct by
 -- construction.
-data Stmt = Stmt Text (NonEmpty Expr)
+data Stmt = Stmt Text [Expr]
   deriving (Show, Eq)
 
 data Expr
@@ -49,8 +49,7 @@ newtype Wildcard = Wildcard [Expr]
   deriving (Show, Eq)
 
 fromKeyedMsg :: Text -> ICU.Message -> ASTCompiler Stmt
-fromKeyedMsg n (ICU.Static x)   = pure $ Stmt n (pure $ TPrint x)
-fromKeyedMsg n (ICU.Dynamic ys) = Stmt n <$> (fromToken `mapM` ys)
+fromKeyedMsg n (ICU.Message xs) = Stmt n <$> (fromToken `mapM` xs)
 
 fromToken :: ICU.Token -> ASTCompiler Expr
 fromToken (ICU.Plaintext x)     = pure $ TPrint x

--- a/lib/Intlc/Backend/JavaScript/Language.hs
+++ b/lib/Intlc/Backend/JavaScript/Language.hs
@@ -52,11 +52,11 @@ fromKeyedMsg :: Text -> ICU.Message -> ASTCompiler Stmt
 fromKeyedMsg n (ICU.Message xs) = Stmt n <$> (fromToken `mapM` xs)
 
 fromToken :: ICU.Token -> ASTCompiler Expr
-fromToken (ICU.Plaintext x)     = pure $ TPrint x
-fromToken (ICU.Interpolation x) = fromArg x
+fromToken (ICU.Plaintext x)       = pure $ TPrint x
+fromToken (ICU.Interpolation x y) = fromInterp x y
 
-fromArg :: ICU.Arg -> ASTCompiler Expr
-fromArg (ICU.Arg nraw t) =
+fromInterp :: Text -> ICU.Type -> ASTCompiler Expr
+fromInterp nraw t =
   case t of
     ICU.Bool { ICU.trueCase, ICU.falseCase } -> do
       x <- fromBoolCase True trueCase

--- a/lib/Intlc/Backend/TypeScript/Compiler.hs
+++ b/lib/Intlc/Backend/TypeScript/Compiler.hs
@@ -16,11 +16,12 @@ import           Utils                             ((<>^))
 
 compileNamedExport :: InterpStrat -> Locale -> Text -> ICU.Message -> Text
 compileNamedExport x l k v =
-  let (n, r) = JS.compileStmtPieces x l k v
-      arg = case v of
-        ICU.Static {}  -> "()"
-        ICU.Dynamic {} -> "x"
-   in "export const " <> n <> ": " <> compileTypeof x v <> " = " <> arg <> " => " <> r
+  "export const " <> n <> ": " <> compileTypeof x v <> " = " <> arg <> " => " <> r
+  where (n, r) = JS.compileStmtPieces x l k v
+        arg = if hasInterpolations then "x" else "()"
+        hasInterpolations = flip any (ICU.unMessage v) $ \case
+          ICU.Interpolation {} -> True
+          ICU.Plaintext {}     -> False
 
 compileTypeof :: InterpStrat -> ICU.Message -> Text
 compileTypeof x = let o = fromStrat x in flip runReader o . typeof . fromMsg o

--- a/lib/Intlc/Backend/TypeScript/Language.hs
+++ b/lib/Intlc/Backend/TypeScript/Language.hs
@@ -41,8 +41,7 @@ collateArgs :: UncollatedArgs -> Args
 collateArgs = fmap nub . M.fromListWith (<>) . fmap (second pure)
 
 fromMsg :: Out -> ICU.Message -> TypeOf
-fromMsg x ICU.Static {}    = Lambda mempty x
-fromMsg x (ICU.Dynamic ys) = Lambda (collateArgs (fromToken =<< toList ys)) x
+fromMsg x (ICU.Message ys) = Lambda (collateArgs (fromToken =<< toList ys)) x
 
 fromToken :: ICU.Token -> UncollatedArgs
 fromToken ICU.Plaintext {}      = mempty

--- a/lib/Intlc/Backend/TypeScript/Language.hs
+++ b/lib/Intlc/Backend/TypeScript/Language.hs
@@ -44,25 +44,25 @@ fromMsg :: Out -> ICU.Message -> TypeOf
 fromMsg x (ICU.Message ys) = Lambda (collateArgs (fromToken =<< toList ys)) x
 
 fromToken :: ICU.Token -> UncollatedArgs
-fromToken ICU.Plaintext {}      = mempty
-fromToken (ICU.Interpolation x) = fromArg x
+fromToken ICU.Plaintext {}        = mempty
+fromToken (ICU.Interpolation x y) = fromInterp x y
 
-fromArg :: ICU.Arg -> UncollatedArgs
-fromArg (ICU.Arg n (ICU.Bool xs ys))   = (n, TBool) : (fromToken =<< xs) <> (fromToken =<< ys)
-fromArg (ICU.Arg n ICU.String)         = pure (n, TStr)
-fromArg (ICU.Arg n ICU.Number)         = pure (n, TNum)
-fromArg (ICU.Arg n ICU.Date {})        = pure (n, TDate)
-fromArg (ICU.Arg n ICU.Time {})        = pure (n, TDate)
-fromArg (ICU.Arg n (ICU.Plural x))     = fromPlural n x
+fromInterp :: Text -> ICU.Type -> UncollatedArgs
+fromInterp n (ICU.Bool xs ys)   = (n, TBool) : (fromToken =<< xs) <> (fromToken =<< ys)
+fromInterp n ICU.String         = pure (n, TStr)
+fromInterp n ICU.Number         = pure (n, TNum)
+fromInterp n ICU.Date {}        = pure (n, TDate)
+fromInterp n ICU.Time {}        = pure (n, TDate)
+fromInterp n (ICU.Plural x)     = fromPlural n x
 -- Plural references are treated as a no-op.
-fromArg (ICU.Arg _ ICU.PluralRef)      = mempty
-fromArg (ICU.Arg n (ICU.Select cs mw)) = (n, t) : (fromSelectCase =<< toList cs) <> foldMap fromSelectWildcard mw
+fromInterp _ ICU.PluralRef      = mempty
+fromInterp n (ICU.Select cs mw) = (n, t) : (fromSelectCase =<< toList cs) <> foldMap fromSelectWildcard mw
   -- When there's no wildcard case we can compile to a union of string literals.
   where t = case mw of
               Just _  -> TStr
               Nothing -> TStrLitUnion $ caseLit <$> cs
         caseLit (ICU.SelectCase x _) = x
-fromArg (ICU.Arg n (ICU.Callback xs))  = (n, TEndo) : (fromToken =<< xs)
+fromInterp n (ICU.Callback xs)  = (n, TEndo) : (fromToken =<< xs)
 
 fromPlural :: Text -> ICU.Plural -> UncollatedArgs
 fromPlural n (ICU.Cardinal (ICU.LitPlural ls mw))      = (n, t) : (fromExactPluralCase =<< toList ls) <> foldMap fromPluralWildcard mw

--- a/lib/Intlc/Compiler.hs
+++ b/lib/Intlc/Compiler.hs
@@ -47,8 +47,7 @@ flattenDataset :: Dataset Translation -> Dataset UnparsedTranslation
 flattenDataset = fmap $ \(Translation msg be md) -> UnparsedTranslation (compileMsg . flatten $ msg) be md
 
 flatten :: ICU.Message -> ICU.Message
-flatten x@(ICU.Static _)      = x
-flatten (ICU.Dynamic xs)      = ICU.Dynamic . fromList . flattenStream . toList $ xs
+flatten (ICU.Message xs)      = ICU.Message . fromList . flattenStream . toList $ xs
   where flattenStream :: ICU.Stream -> ICU.Stream
         flattenStream ys = fromMaybe ys $ choice
           [ mapBool   <$> extractFirstBool ys

--- a/lib/Intlc/Compiler.hs
+++ b/lib/Intlc/Compiler.hs
@@ -59,7 +59,7 @@ flatten (ICU.Message xs)      = ICU.Message . fromList . flattenStream . toList 
         mapPlural (n, ls, plu, rs) = streamFromArg n .         ICU.Plural $ mapPluralStreams (around ls rs) plu
         around ls rs = flattenStream . ICU.mergePlaintext . surround ls rs
         surround ls rs cs = ls <> cs <> rs
-        streamFromArg n = pure . ICU.Interpolation . ICU.Arg n
+        streamFromArg n = pure . ICU.Interpolation n
 
 extractFirstBool :: ICU.Stream -> Maybe (Text, ICU.Stream, ICUBool, ICU.Stream)
 extractFirstBool = extractFirstArg $ \case
@@ -68,7 +68,7 @@ extractFirstBool = extractFirstArg $ \case
 
 extractFirstArg :: (ICU.Type -> Maybe a) -> ICU.Stream -> Maybe (Text, ICU.Stream, a, ICU.Stream)
 extractFirstArg f xs = firstJust arg (zip [0..] xs)
-  where arg (i, ICU.Interpolation (ICU.Arg n t)) = (n, ls, , rs) <$> f t
+  where arg (i, ICU.Interpolation n t) = (n, ls, , rs) <$> f t
           where (ls, _:rs) = splitAt i xs
         arg _ = Nothing
 

--- a/lib/Intlc/ICU.hs
+++ b/lib/Intlc/ICU.hs
@@ -18,7 +18,7 @@ type Stream = [Token]
 -- message without any interpolation will be a single `Plaintext` token.
 data Token
   = Plaintext Text
-  | Interpolation Arg
+  | Interpolation Text Type
   deriving (Show, Eq)
 
 -- | Merges any sibling `Plaintext` tokens in a `Stream`.
@@ -26,9 +26,6 @@ mergePlaintext :: Stream -> Stream
 mergePlaintext []                               = []
 mergePlaintext (Plaintext x : Plaintext y : zs) = mergePlaintext $ Plaintext (x <> y) : zs
 mergePlaintext (x:ys)                           = x : mergePlaintext ys
-
-data Arg = Arg Text Type
-  deriving (Show, Eq)
 
 -- We diverge from icu4j by supporting a boolean type, and not necessarily
 -- requiring wildcard cases.

--- a/lib/Intlc/ICU.hs
+++ b/lib/Intlc/ICU.hs
@@ -5,12 +5,12 @@ module Intlc.ICU where
 
 import           Prelude hiding (Type)
 
-data Message
-  = Static Text
-  | Dynamic NEStream
+newtype Message = Message Stream
   deriving (Show, Eq)
 
-type NEStream = NonEmpty Token
+unMessage :: Message -> Stream
+unMessage (Message xs) = xs
+
 type Stream = [Token]
 
 -- | A token is either an interpolation - some sort of identifier for input -

--- a/lib/Intlc/Parser/ICU.hs
+++ b/lib/Intlc/Parser/ICU.hs
@@ -39,10 +39,7 @@ ident :: Parser Text
 ident = T.pack <$> some letterChar
 
 toMsg :: Stream -> Message
-toMsg = mergePlaintext >>> \case
-  []            -> Static ""
-  [Plaintext x] -> Static x
-  (x:xs)        -> Dynamic (x :| xs)
+toMsg = Message . mergePlaintext
 
 msg :: Parser Message
 msg = toMsg <$> manyTill token eof

--- a/test/Intlc/Backend/TypeScriptSpec.hs
+++ b/test/Intlc/Backend/TypeScriptSpec.hs
@@ -28,7 +28,7 @@ golden strat compiler name msg = baseCfg
 spec :: Spec
 spec = describe "TypeScript compiler" $ do
   describe "golden" $ do
-    let msg = ICU.Dynamic . fromList $
+    let msg = ICU.Message $
           [ ICU.Plaintext "Hello "
           , ICU.Interpolation (ICU.Arg "bold" (ICU.Callback (pure $
               ICU.Interpolation (ICU.Arg "name" ICU.String
@@ -91,7 +91,7 @@ spec = describe "TypeScript compiler" $ do
 
   describe "collects nested arguments" $ do
     let args (TS.Lambda xs _) = xs
-    let fromToken = args . TS.fromMsg TS.TFragment . ICU.Dynamic . pure . ICU.Interpolation . ICU.Arg "x"
+    let fromToken = args . TS.fromMsg TS.TFragment . ICU.Message . pure . ICU.Interpolation . ICU.Arg "x"
     let fromArgs = fromList
 
     it "in select" $ do

--- a/test/Intlc/Backend/TypeScriptSpec.hs
+++ b/test/Intlc/Backend/TypeScriptSpec.hs
@@ -30,34 +30,34 @@ spec = describe "TypeScript compiler" $ do
   describe "golden" $ do
     let msg = ICU.Message $
           [ ICU.Plaintext "Hello "
-          , ICU.Interpolation (ICU.Arg "bold" (ICU.Callback (pure $
-              ICU.Interpolation (ICU.Arg "name" ICU.String
-            ))))
+          , ICU.Interpolation "bold" (ICU.Callback (pure $
+              ICU.Interpolation "name" ICU.String
+            ))
           , ICU.Plaintext "! You are "
-          , ICU.Interpolation (ICU.Arg "age" (ICU.Plural (ICU.Cardinal
+          , ICU.Interpolation "age" (ICU.Plural (ICU.Cardinal
               (ICU.MixedPlural
               (pure (ICU.PluralCase (ICU.PluralExact "42") (pure (ICU.Plaintext "very cool"))))
               (pure (ICU.PluralCase ICU.Zero (pure (ICU.Plaintext "new around here"))))
               (ICU.PluralWildcard (pure (ICU.Plaintext "not all that interesting")))
               )
-            )))
+            ))
           , ICU.Plaintext ". Regardless, the magic number is most certainly "
-          , ICU.Interpolation (ICU.Arg "magicNumber" ICU.Number)
+          , ICU.Interpolation "magicNumber" ICU.Number
           , ICU.Plaintext "! The date is "
-          , ICU.Interpolation (ICU.Arg "todayDate" (ICU.Date ICU.Short))
+          , ICU.Interpolation "todayDate" (ICU.Date ICU.Short)
           , ICU.Plaintext ", and the time is "
-          , ICU.Interpolation (ICU.Arg "currTime" (ICU.Time ICU.Full))
+          , ICU.Interpolation "currTime" (ICU.Time ICU.Full)
           , ICU.Plaintext ". And just to recap, your name is "
-          , ICU.Interpolation (ICU.Arg "name" (ICU.Select (fromList
+          , ICU.Interpolation "name" (ICU.Select (fromList
               [ ICU.SelectCase "Sam" [ICU.Plaintext "undoubtedly excellent"]
               , ICU.SelectCase "Ashley" [ICU.Plaintext "fairly good"]
               ]
-            ) Nothing))
+            ) Nothing)
           , ICU.Plaintext ". Finally, you are "
-          , ICU.Interpolation (ICU.Arg "isDev" (ICU.Bool
+          , ICU.Interpolation "isDev" (ICU.Bool
             { ICU.trueCase = [ICU.Plaintext "a software engineer"]
             , ICU.falseCase = [ICU.Plaintext "something less fun"]
-            }))
+            })
           , ICU.Plaintext ". Bonus: Some characters that might need escaping! ` ``"
           ]
 
@@ -91,11 +91,11 @@ spec = describe "TypeScript compiler" $ do
 
   describe "collects nested arguments" $ do
     let args (TS.Lambda xs _) = xs
-    let fromToken = args . TS.fromMsg TS.TFragment . ICU.Message . pure . ICU.Interpolation . ICU.Arg "x"
+    let fromToken = args . TS.fromMsg TS.TFragment . ICU.Message . pure . ICU.Interpolation "x"
     let fromArgs = fromList
 
     it "in select" $ do
-      let x = flip ICU.Select Nothing . pure $ ICU.SelectCase "foo" [ICU.Interpolation $ ICU.Arg "y" ICU.String]
+      let x = flip ICU.Select Nothing . pure $ ICU.SelectCase "foo" [ICU.Interpolation "y" ICU.String]
       let ys =
               [ ("x", pure (TS.TStrLitUnion (pure "foo")))
               , ("y", pure TS.TStr)
@@ -104,7 +104,7 @@ spec = describe "TypeScript compiler" $ do
 
     it "in cardinal plural" $ do
       let x = ICU.Plural . ICU.Cardinal . flip ICU.LitPlural Nothing . pure $
-                ICU.PluralCase (ICU.PluralExact "42") [ICU.Interpolation $ ICU.Arg "y" ICU.String]
+                ICU.PluralCase (ICU.PluralExact "42") [ICU.Interpolation "y" ICU.String]
       let ys =
               [ ("x", pure (TS.TNumLitUnion (pure "42")))
               , ("y", pure TS.TStr)
@@ -113,9 +113,9 @@ spec = describe "TypeScript compiler" $ do
 
     it "in ordinal plural" $ do
       let x = ICU.Plural . ICU.Ordinal $ ICU.OrdinalPlural
-                [ICU.PluralCase (ICU.PluralExact "42") [ICU.Interpolation $ ICU.Arg "foo" (ICU.Date ICU.Short)]]
-                (pure $ ICU.PluralCase ICU.Few [ICU.Interpolation $ ICU.Arg "bar" ICU.String])
-                (ICU.PluralWildcard [ICU.Interpolation $ ICU.Arg "baz" ICU.Number])
+                [ICU.PluralCase (ICU.PluralExact "42") [ICU.Interpolation "foo" (ICU.Date ICU.Short)]]
+                (pure $ ICU.PluralCase ICU.Few [ICU.Interpolation "bar" ICU.String])
+                (ICU.PluralWildcard [ICU.Interpolation "baz" ICU.Number])
       let ys =
               [ ("x", pure TS.TNum)
               , ("foo", pure TS.TDate)
@@ -126,8 +126,8 @@ spec = describe "TypeScript compiler" $ do
 
     it "in boolean" $ do
       let x = ICU.Bool
-                [ICU.Interpolation $ ICU.Arg "y" ICU.String]
-                [ICU.Interpolation $ ICU.Arg "z" ICU.Number]
+                [ICU.Interpolation "y" ICU.String]
+                [ICU.Interpolation "z" ICU.Number]
       let ys =
               [ ("x", pure TS.TBool)
               , ("y", pure TS.TStr)

--- a/test/Intlc/CompilerSpec.hs
+++ b/test/Intlc/CompilerSpec.hs
@@ -34,12 +34,12 @@ spec = describe "compiler" $ do
         let other = SelectWildcard [Plaintext "many dogs"]
         let otherf = SelectWildcard [Plaintext "I have many dogs"]
 
-        flatten (Message [Plaintext "I have ", Interpolation (Arg "thing" (Select (pure foo) (pure other)))]) `shouldBe`
-          Message (pure $ Interpolation (Arg "thing" (Select (pure foof) (pure otherf))))
+        flatten (Message [Plaintext "I have ", Interpolation "thing" (Select (pure foo) (pure other))]) `shouldBe`
+          Message (pure $ Interpolation "thing" (Select (pure foof) (pure otherf)))
 
       it "without a wildcard" $ do
-        flatten (Message [Plaintext "I have ", Interpolation (Arg "thing" (Select (pure foo) empty))]) `shouldBe`
-          Message (pure $ Interpolation (Arg "thing" (Select (pure foof) empty)))
+        flatten (Message [Plaintext "I have ", Interpolation "thing" (Select (pure foo) empty)]) `shouldBe`
+          Message (pure $ Interpolation "thing" (Select (pure foof) empty))
 
     it "flattens shallow plural" $ do
       let other = PluralWildcard [Plaintext "many dogs"]
@@ -47,18 +47,18 @@ spec = describe "compiler" $ do
       let one = PluralCase One [Plaintext "a dog"]
       let onef = PluralCase One [Plaintext "I have a dog"]
 
-      flatten (Message [Plaintext "I have ", Interpolation (Arg "count" (Plural (Cardinal (RulePlural (pure one) other))))]) `shouldBe`
-        Message (pure $ Interpolation (Arg "count" (Plural (Cardinal (RulePlural (pure onef) otherf)))))
+      flatten (Message [Plaintext "I have ", Interpolation "count" (Plural (Cardinal (RulePlural (pure one) other)))]) `shouldBe`
+        Message (pure $ Interpolation "count" (Plural (Cardinal (RulePlural (pure onef) otherf))))
 
     it "flattens deep interpolations" $ do
       let x = Message $
             [ Plaintext "I have "
-            , Interpolation . Arg "count" . Plural . Cardinal $ RulePlural
+            , Interpolation "count" . Plural . Cardinal $ RulePlural
               (pure $ PluralCase One [Plaintext "a dog"])
               (PluralWildcard
-                [ Interpolation $ Arg "count" Number
+                [ Interpolation "count" Number
                 , Plaintext " dogs, the newest of which is "
-                , Interpolation . Arg "name" $ Select
+                , Interpolation "name" $ Select
                   (pure $ SelectCase "hodor" [Plaintext "Hodor"])
                   (pure $ SelectWildcard [Plaintext "unknown"])
                 ]
@@ -66,19 +66,19 @@ spec = describe "compiler" $ do
             , Plaintext "!"
             ]
       let y = Message . pure $
-            Interpolation . Arg "count" . Plural . Cardinal $ RulePlural
+            Interpolation "count" . Plural . Cardinal $ RulePlural
               (pure $ PluralCase One [Plaintext "I have a dog!"])
               (PluralWildcard
-                [ Interpolation . Arg "name" $ Select
+                [ Interpolation "name" $ Select
                   (pure $ SelectCase "hodor"
                     [ Plaintext "I have "
-                    , Interpolation $ Arg "count" Number
+                    , Interpolation "count" Number
                     , Plaintext " dogs, the newest of which is Hodor!"
                     ]
                   )
                   (pure $ SelectWildcard
                     [ Plaintext "I have "
-                    , Interpolation $ Arg "count" Number
+                    , Interpolation "count" Number
                     , Plaintext " dogs, the newest of which is unknown!"
                     ]
                   )


### PR DESCRIPTION
This had been bugging me for a while and came up when talking to @Magellol.

`ICU.Message` was a sum type (`Static | Dynamic`) and is now a newtype holding a `Stream`. `NEStream` (non-empty `Stream`) is removed. There was only one part of the codebase that cared about whether the message was static or not, the TypeScript compiler as it pertains to the argument (`x` or `()`), and that's trivially replaced with a quick `any` call.

`ICU.Arg` was essentially just an additional wrapper around `ICU.Interpolation`'s data (name and type).