### PR TITLE
Fix dangling space in ICU compiler literal plural output

### DIFF
--- a/lib/Intlc/Backend/ICU/Compiler.hs
+++ b/lib/Intlc/Backend/ICU/Compiler.hs
@@ -40,7 +40,7 @@ dateTimeFmt Long   = "long"
 dateTimeFmt Full   = "full"
 
 cardinalPlural :: CardinalPlural -> Text
-cardinalPlural (LitPlural xs mw)     = unwords $ (toList $ exactPluralCase <$> xs) <> foldMap (pure . pluralWildcard) mw
+cardinalPlural (LitPlural xs mw)     = unwords $ toList (exactPluralCase <$> xs) <> foldMap (pure . pluralWildcard) mw
 cardinalPlural (RulePlural xs w)     = unwords . toList $ (rulePluralCase <$> xs) <> pure (pluralWildcard w)
 cardinalPlural (MixedPlural xs ys w) = unwords . toList $ (exactPluralCase <$> xs) <> (rulePluralCase <$> ys) <> pure (pluralWildcard w)
 

--- a/lib/Intlc/Backend/ICU/Compiler.hs
+++ b/lib/Intlc/Backend/ICU/Compiler.hs
@@ -40,7 +40,7 @@ dateTimeFmt Long   = "long"
 dateTimeFmt Full   = "full"
 
 cardinalPlural :: CardinalPlural -> Text
-cardinalPlural (LitPlural xs mw)     = unwords . toList $ (exactPluralCase <$> xs) <> foldMapM (pure . pluralWildcard) mw
+cardinalPlural (LitPlural xs mw)     = unwords $ (toList $ exactPluralCase <$> xs) <> foldMap (pure . pluralWildcard) mw
 cardinalPlural (RulePlural xs w)     = unwords . toList $ (rulePluralCase <$> xs) <> pure (pluralWildcard w)
 cardinalPlural (MixedPlural xs ys w) = unwords . toList $ (exactPluralCase <$> xs) <> (rulePluralCase <$> ys) <> pure (pluralWildcard w)
 


### PR DESCRIPTION
Fixes #97.

Given via `intlc flatten`:

```json
{
  "f": {
    "message": "{n, plural, =1 {}}"
  }
}
```

Before:

```
{"f":{"message":"{n, plural, =1 {} }","backend":"ts","description":null}}
```

After:

```
{"f":{"message":"{n, plural, =1 {}}","backend":"ts","description":null}}
```

---

I'm going to be lazy and not add a test for this on the basis that:

1. It's not a major bug if it happens again.
2. Testing is tracked as part of a larger issue at #49, sort of.
3. Testing is _really_ implicitly tracked by #129 which will presumably rely upon this very ICU compiler.