### PR TITLE
Add plural expansion

### DIFF
--- a/internal/CLI.hs
+++ b/internal/CLI.hs
@@ -8,18 +8,24 @@ import           Prelude
 
 data Opts
   = Lint FilePath
+  -- Takes stdin.
+  | ExpandPlurals
 
 getOpts :: IO Opts
 getOpts = execParser (info (opts <**> helper) (progDesc h))
   where h = "Additional tooling for Unsplash."
 
 opts :: Parser Opts
-opts = subparser
-  ( command "lint" (info (lint <**> helper) mempty)
-  )
+opts = subparser . mconcat $
+  [ command "lint" (info (lint <**> helper) mempty)
+  , command "expand-plurals" (info (expandPlurals <**> helper) mempty)
+  ]
 
 lint :: Parser Opts
 lint = Lint <$> pathp
+
+expandPlurals :: Parser Opts
+expandPlurals = pure ExpandPlurals
 
 pathp :: Parser FilePath
 pathp = argument str (metavar "filepath")

--- a/internal/Main.hs
+++ b/internal/Main.hs
@@ -1,22 +1,29 @@
 module Main where
 
-import           CLI                (Opts (..), getOpts)
-import qualified Data.Map           as M
-import qualified Data.Text          as T
+import           CLI                         (Opts (..), getOpts)
+import qualified Data.Map                    as M
+import qualified Data.Text                   as T
+import           Data.Text.IO                (getContents)
+import           Intlc.Backend.JSON.Compiler (compileDataset)
+import           Intlc.Compiler              (expandPlurals)
 import           Intlc.Core
 import           Intlc.Linter
-import           Intlc.Parser       (parseDataset, printErr)
-import           Intlc.Parser.Error (ParseFailure)
-import           Prelude            hiding (filter)
+import           Intlc.Parser                (parseDataset, printErr)
+import           Intlc.Parser.Error          (ParseFailure)
+import           Prelude                     hiding (filter)
 
 main :: IO ()
 main = getOpts >>= \case
-  Lint path -> either parserDie lint' =<< getParsed path
+  Lint path     -> either parserDie lint' =<< getParsed path
+  ExpandPlurals -> either parserDie expandPlurals' . parseDataset "stdin" =<< getContents
   where
     getParsed :: FilePath -> IO (Either ParseFailure (Dataset Translation))
     getParsed x = parseDataset x <$> readFileText x
 
     parserDie = die . printErr
+
+    expandPlurals' :: Dataset Translation -> IO ()
+    expandPlurals' = putTextLn . compileDataset . fmap (\x -> x { message = expandPlurals (message x) })
 
     lint' :: Dataset Translation -> IO ()
     lint' = exit . M.mapMaybe (statusToMaybe . lint . message)

--- a/lib/Intlc/Compiler.hs
+++ b/lib/Intlc/Compiler.hs
@@ -45,7 +45,7 @@ mapMsgs :: (ICU.Message -> ICU.Message) -> Dataset Translation -> Dataset Transl
 mapMsgs f = fmap $ \x -> x { message = f (message x) }
 
 flatten :: ICU.Message -> ICU.Message
-flatten (ICU.Message xs) = ICU.Message . fromList . flattenStream . toList $ xs
+flatten (ICU.Message xs) = ICU.Message . flattenStream $ xs
   where flattenStream :: ICU.Stream -> ICU.Stream
         flattenStream ys = fromMaybe ys $ choice
           [ mapBool   <$> extractFirstBool ys

--- a/lib/Intlc/Compiler.hs
+++ b/lib/Intlc/Compiler.hs
@@ -45,7 +45,7 @@ mapMsgs :: (ICU.Message -> ICU.Message) -> Dataset Translation -> Dataset Transl
 mapMsgs f = fmap $ \x -> x { message = f (message x) }
 
 flatten :: ICU.Message -> ICU.Message
-flatten (ICU.Message xs)      = ICU.Message . fromList . flattenStream . toList $ xs
+flatten (ICU.Message xs) = ICU.Message . fromList . flattenStream . toList $ xs
   where flattenStream :: ICU.Stream -> ICU.Stream
         flattenStream ys = fromMaybe ys $ choice
           [ mapBool   <$> extractFirstBool ys

--- a/lib/Intlc/ICU.hs
+++ b/lib/Intlc/ICU.hs
@@ -146,7 +146,7 @@ data PluralRule
   | Two
   | Few
   | Many
-  deriving (Show, Eq)
+  deriving (Show, Eq, Ord, Enum, Bounded)
 
 newtype PluralWildcard = PluralWildcard Stream
   deriving (Show, Eq)

--- a/test/Intlc/EndToEndSpec.hs
+++ b/test/Intlc/EndToEndSpec.hs
@@ -32,55 +32,56 @@ withReactImport = ("import { ReactElement } from 'react'\n" <>)
 
 spec :: Spec
 spec = describe "end-to-end" $ do
-  it "example message" $ do
-    golden "example" [r|{ "title": { "message": "Unsplash" }, "greeting": { "message": "Hello <bold>{name}</bold>, {age, number}!", "backend": "ts" } }|]
+  describe "compile" $ do
+    it "example message" $ do
+      golden "example" [r|{ "title": { "message": "Unsplash" }, "greeting": { "message": "Hello <bold>{name}</bold>, {age, number}!", "backend": "ts" } }|]
 
-  it "compiles valid JS module format given empty input" $ do
-    [r|{}|]
-      =*= "export {}"
+    it "compiles valid JS module format given empty input" $ do
+      [r|{}|]
+        =*= "export {}"
 
-  it "parses and discards descriptions" $ do
-    [r|{ "brand": { "message": "Unsplash", "description": "The company name" } }|]
-      =*= "export const brand: () => string = () => `Unsplash`"
+    it "parses and discards descriptions" $ do
+      [r|{ "brand": { "message": "Unsplash", "description": "The company name" } }|]
+        =*= "export const brand: () => string = () => `Unsplash`"
 
-  it "outputs in alphabetical order" $ do
-    [r|{ "x": { "message": "" }, "A": { "message": "" }, "z": { "message": "" } }|]
-      =*= "export const A: () => string = () => ``\nexport const x: () => string = () => ``\nexport const z: () => string = () => ``"
+    it "outputs in alphabetical order" $ do
+      [r|{ "x": { "message": "" }, "A": { "message": "" }, "z": { "message": "" } }|]
+        =*= "export const A: () => string = () => ``\nexport const x: () => string = () => ``\nexport const z: () => string = () => ``"
 
-  it "compiles bools" $ do
-    [r|{ "f": { "message": "{x, boolean, true {y} false {z}}" } }|]
-      =*= "export const f: (x: { x: boolean }) => string = x => `${(() => { switch (x.x as typeof x.x) { case true: return `y`; case false: return `z`; } })()}`"
+    it "compiles bools" $ do
+      [r|{ "f": { "message": "{x, boolean, true {y} false {z}}" } }|]
+        =*= "export const f: (x: { x: boolean }) => string = x => `${(() => { switch (x.x as typeof x.x) { case true: return `y`; case false: return `z`; } })()}`"
 
-  it "compiles plurals" $ do
-    [r|{ "prop": { "message": "Age: {age, plural, =0 {newborn called {name}} =42 {magical} other {boring #}}", "backend": "ts" } }|]
-      =*= "export const prop: (x: { age: number; name: string }) => string = x => `Age: ${(() => { switch (x.age as typeof x.age) { case 0: return `newborn called ${x.name}`; case 42: return `magical`; default: return `boring ${new Intl.NumberFormat('en-US').format(x.age)}`; } })()}`"
-    [r|{ "prop": { "message": "Age: {age, plural, =0 {newborn called {name}} =42 {magical} other {boring #}}", "backend": "tsx" } }|]
-      =*= withReactImport "export const prop: (x: { age: number; name: string }) => ReactElement = x => <>Age: {(() => { switch (x.age as typeof x.age) { case 0: return <>newborn called {x.name}</>; case 42: return <>magical</>; default: return <>boring {new Intl.NumberFormat('en-US').format(x.age)}</>; } })()}</>"
-    [r|{ "f": { "message": "{n, plural, =0 {x} =42 {y}}", "backend": "ts" } }|]
-      =*= "export const f: (x: { n: 0 | 42 }) => string = x => `${(() => { switch (x.n as typeof x.n) { case 0: return `x`; case 42: return `y`; } })()}`"
-    [r|{ "f": { "message": "{n, plural, =0 {zero} many {many} other {#}}", "backend": "ts" } }|]
-      =*= "export const f: (x: { n: number }) => string = x => `${(() => { switch (x.n as typeof x.n) { case 0: return `zero`; default: { switch (new Intl.PluralRules('en-US').select(x.n)) { case 'many': return `many`; default: return `${new Intl.NumberFormat('en-US').format(x.n)}`; } } } })()}`"
-    [r|{ "f": { "message": "{n, plural, many {many} other {#}}", "backend": "ts" } }|]
-      =*= "export const f: (x: { n: number }) => string = x => `${(() => { switch (new Intl.PluralRules('en-US').select(x.n)) { case 'many': return `many`; default: return `${new Intl.NumberFormat('en-US').format(x.n)}`; } })()}`"
-    [r|{ "f": { "message": "{n, plural, =42 {#}}" } }|]
-      =*= "export const f: (x: { n: 42 }) => string = x => `${(() => { switch (x.n as typeof x.n) { case 42: return `${new Intl.NumberFormat('en-US').format(x.n)}`; } })()}`"
+    it "compiles plurals" $ do
+      [r|{ "prop": { "message": "Age: {age, plural, =0 {newborn called {name}} =42 {magical} other {boring #}}", "backend": "ts" } }|]
+        =*= "export const prop: (x: { age: number; name: string }) => string = x => `Age: ${(() => { switch (x.age as typeof x.age) { case 0: return `newborn called ${x.name}`; case 42: return `magical`; default: return `boring ${new Intl.NumberFormat('en-US').format(x.age)}`; } })()}`"
+      [r|{ "prop": { "message": "Age: {age, plural, =0 {newborn called {name}} =42 {magical} other {boring #}}", "backend": "tsx" } }|]
+        =*= withReactImport "export const prop: (x: { age: number; name: string }) => ReactElement = x => <>Age: {(() => { switch (x.age as typeof x.age) { case 0: return <>newborn called {x.name}</>; case 42: return <>magical</>; default: return <>boring {new Intl.NumberFormat('en-US').format(x.age)}</>; } })()}</>"
+      [r|{ "f": { "message": "{n, plural, =0 {x} =42 {y}}", "backend": "ts" } }|]
+        =*= "export const f: (x: { n: 0 | 42 }) => string = x => `${(() => { switch (x.n as typeof x.n) { case 0: return `x`; case 42: return `y`; } })()}`"
+      [r|{ "f": { "message": "{n, plural, =0 {zero} many {many} other {#}}", "backend": "ts" } }|]
+        =*= "export const f: (x: { n: number }) => string = x => `${(() => { switch (x.n as typeof x.n) { case 0: return `zero`; default: { switch (new Intl.PluralRules('en-US').select(x.n)) { case 'many': return `many`; default: return `${new Intl.NumberFormat('en-US').format(x.n)}`; } } } })()}`"
+      [r|{ "f": { "message": "{n, plural, many {many} other {#}}", "backend": "ts" } }|]
+        =*= "export const f: (x: { n: number }) => string = x => `${(() => { switch (new Intl.PluralRules('en-US').select(x.n)) { case 'many': return `many`; default: return `${new Intl.NumberFormat('en-US').format(x.n)}`; } })()}`"
+      [r|{ "f": { "message": "{n, plural, =42 {#}}" } }|]
+        =*= "export const f: (x: { n: 42 }) => string = x => `${(() => { switch (x.n as typeof x.n) { case 42: return `${new Intl.NumberFormat('en-US').format(x.n)}`; } })()}`"
 
-  it "compiles select" $ do
-    [r|{ "f": { "message": "{x, select, a {hi} b {yo}}", "backend": "ts" } }|]
-      =*= "export const f: (x: { x: 'a' | 'b' }) => string = x => `${(() => { switch (x.x as typeof x.x) { case 'a': return `hi`; case 'b': return `yo`; } })()}`"
-    [r|{ "f": { "message": "{x, select, a {hi} b {yo} other {ciao}}", "backend": "ts" } }|]
-      =*= "export const f: (x: { x: string }) => string = x => `${(() => { switch (x.x as typeof x.x) { case 'a': return `hi`; case 'b': return `yo`; default: return `ciao`; } })()}`"
+    it "compiles select" $ do
+      [r|{ "f": { "message": "{x, select, a {hi} b {yo}}", "backend": "ts" } }|]
+        =*= "export const f: (x: { x: 'a' | 'b' }) => string = x => `${(() => { switch (x.x as typeof x.x) { case 'a': return `hi`; case 'b': return `yo`; } })()}`"
+      [r|{ "f": { "message": "{x, select, a {hi} b {yo} other {ciao}}", "backend": "ts" } }|]
+        =*= "export const f: (x: { x: string }) => string = x => `${(() => { switch (x.x as typeof x.x) { case 'a': return `hi`; case 'b': return `yo`; default: return `ciao`; } })()}`"
 
-  it "compiles selectordinal" $ do
-    [r|{ "f": { "message": "{x, selectordinal, one {foo} other {bar}}", "backend": "ts" } }|]
-      =*= "export const f: (x: { x: number }) => string = x => `${(() => { switch (new Intl.PluralRules('en-US', { type: 'ordinal' }).select(x.x)) { case 'one': return `foo`; default: return `bar`; } })()}`"
-    [r|{ "f": { "message": "{x, selectordinal, one {foo} =2 {bar} other {baz}}", "backend": "ts" } }|]
-      =*= "export const f: (x: { x: number }) => string = x => `${(() => { switch (x.x as typeof x.x) { case 2: return `bar`; default: { switch (new Intl.PluralRules('en-US', { type: 'ordinal' }).select(x.x)) { case 'one': return `foo`; default: return `baz`; } } } })()}`"
+    it "compiles selectordinal" $ do
+      [r|{ "f": { "message": "{x, selectordinal, one {foo} other {bar}}", "backend": "ts" } }|]
+        =*= "export const f: (x: { x: number }) => string = x => `${(() => { switch (new Intl.PluralRules('en-US', { type: 'ordinal' }).select(x.x)) { case 'one': return `foo`; default: return `bar`; } })()}`"
+      [r|{ "f": { "message": "{x, selectordinal, one {foo} =2 {bar} other {baz}}", "backend": "ts" } }|]
+        =*= "export const f: (x: { x: number }) => string = x => `${(() => { switch (x.x as typeof x.x) { case 2: return `bar`; default: { switch (new Intl.PluralRules('en-US', { type: 'ordinal' }).select(x.x)) { case 'one': return `foo`; default: return `baz`; } } } })()}`"
 
-  it "TypeScript backend" $ do
-    [r|{ "f": { "message": "{x} <z>{y, number}</z> {y, number}", "backend": "ts" } }|]
-      =*= "export const f: (x: { x: string; y: number; z: (x: string) => string }) => string = x => `${x.x} ${x.z(`${new Intl.NumberFormat('en-US').format(x.y)}`)} ${new Intl.NumberFormat('en-US').format(x.y)}`"
+    it "TypeScript backend" $ do
+      [r|{ "f": { "message": "{x} <z>{y, number}</z> {y, number}", "backend": "ts" } }|]
+        =*= "export const f: (x: { x: string; y: number; z: (x: string) => string }) => string = x => `${x.x} ${x.z(`${new Intl.NumberFormat('en-US').format(x.y)}`)} ${new Intl.NumberFormat('en-US').format(x.y)}`"
 
-  it "TypeScriptReact backend" $ do
-    [r|{ "f": { "message": "{x} <z>{y, number}</z>", "backend": "tsx" } }|]
-      =*= withReactImport "export const f: (x: { x: string; y: number; z: (x: ReactElement) => ReactElement }) => ReactElement = x => <>{x.x} {x.z(<>{new Intl.NumberFormat('en-US').format(x.y)}</>)}</>"
+    it "TypeScriptReact backend" $ do
+      [r|{ "f": { "message": "{x} <z>{y, number}</z>", "backend": "tsx" } }|]
+        =*= withReactImport "export const f: (x: { x: string; y: number; z: (x: ReactElement) => ReactElement }) => ReactElement = x => <>{x.x} {x.z(<>{new Intl.NumberFormat('en-US').format(x.y)}</>)}</>"

--- a/test/Intlc/EndToEndSpec.hs
+++ b/test/Intlc/EndToEndSpec.hs
@@ -24,15 +24,12 @@ golden name in' = baseCfg
         fromErrs (Right x) = x
         fromErrs (Left es) = T.intercalate "\n" . toList $ es
 
-(=*=) :: Text -> Text -> IO ()
-x =*= y = parseAndCompileDataset x `shouldBe` Right y
-
-withReactImport :: Text -> Text
-withReactImport = ("import { ReactElement } from 'react'\n" <>)
-
 spec :: Spec
 spec = describe "end-to-end" $ do
   describe "compile" $ do
+    let x =*= y = parseAndCompileDataset x `shouldBe` Right y
+    let withReactImport = ("import { ReactElement } from 'react'\n" <>)
+
     it "example message" $ do
       golden "example" [r|{ "title": { "message": "Unsplash" }, "greeting": { "message": "Hello <bold>{name}</bold>, {age, number}!", "backend": "ts" } }|]
 


### PR DESCRIPTION
Closes #138.

Adds plural expansion to the internal CLI, operating via stdin and stdout to make its use prior to zipping comfortable. Because we only expand plurals with a wildcard, this should never result in a different compiled type signature (`other`/wildcard means widened `number` as opposed to literals), and as such we shouldn't need to apply this to our own master English translations. This means we do not add plural forms for a literal plural like `{n, plural, =0 {x} =1 {y}}` (which compiles to `n: 0 | 1`), but I don't think we use these much. Plural expansion applies to both `plural` and `selectordinal`, which each fall under the `Plural` type in our AST.

```console
$ echo '{"f":{"message": "You have {n, plural, one {cat} other {cats}}!"}}' | intlc-internal expand-plurals
{"f":{"message":"You have {n, plural, one {cat} zero {cats} two {cats} few {cats} many {cats} other {cats}}!","backend":"ts","description":null}}
```

Traversing streams ergonomically continues to be a challenge (#48). The CLI interfaces could probably do with some tidying up but that can wait for another PR.