### PR TITLE
Fix escaping exceeding message bounds

### DIFF
--- a/lib/Intlc/Parser/ICU.hs
+++ b/lib/Intlc/Parser/ICU.hs
@@ -87,10 +87,15 @@ escaped = apos *> choice
   where apos = char '\''
         syn = char '{' <|> char '<'
         -- Like `someTill`, but doesn't end upon encountering two `end` tokens,
-        -- instead consuming them as one and continuing.
+        -- instead consuming them as one and continuing. A little less abstract
+        -- though as we'll check for only a single end of input token.
         someTillNotDouble p end = tryOne
           where tryOne = (:) <$> p <*> go
-                go = ((:) <$> try (end <* end) <*> go) <|> (mempty <$ end) <|> tryOne
+                go = choice
+                  [ (:) <$> try (end <* end) <*> go
+                  , (mempty <$ end)
+                  , tryOne
+                  ]
 
 callback :: Parser (Text, Type)
 callback = do

--- a/lib/Intlc/Parser/ICU.hs
+++ b/lib/Intlc/Parser/ICU.hs
@@ -103,7 +103,8 @@ escaped = apos *> choice
   , T.singleton <$> synAll
   ]
   where apos = char '\''
-        synAll = synOpen <|> synClose
+        synAll = synLone <|> synOpen <|> synClose
+        synLone = char '#'
         synOpen = char '{' <|> char '<'
         synClose = char '}' <|> char '>'
 

--- a/lib/Intlc/Parser/ICU.hs
+++ b/lib/Intlc/Parser/ICU.hs
@@ -33,8 +33,8 @@ data ParserState = ParserState
   , endOfInput    :: Parser ()
   }
 
-initialState :: ParserState
-initialState = ParserState
+emptyState :: ParserState
+emptyState = ParserState
   { pluralCtxName = Nothing
   , endOfInput = pure ()
   }

--- a/lib/Intlc/Parser/JSON.hs
+++ b/lib/Intlc/Parser/JSON.hs
@@ -23,7 +23,7 @@ import qualified Intlc.ICU                        as ICU
 import           Intlc.Parser.Error               (JSONParseErr (..),
                                                    ParseErr (FailedJSONParse),
                                                    failingWith)
-import           Intlc.Parser.ICU                 (initialState, toMsg, token)
+import qualified Intlc.Parser.ICU                 as ICUP
 import           Prelude                          hiding (null)
 import           Text.Megaparsec                  hiding (State, Stream, Token,
                                                    many, some, token)
@@ -58,7 +58,8 @@ translation = obj $ intercalateEffect objSep $ Translation
 
 msg :: Parser ICU.Message
 msg = lift $ withRecovery recover p
-  where p = toMsg <$> runReaderT (char '"' *> manyTill token (char '"')) initialState
+  where p = runReaderT (char '"' *> ICUP.msg) icupState
+        icupState = ICUP.initialState { ICUP.endOfInput = void $ char '"' }
         recover e = error "absurd" <$ consume <* registerParseError e
         -- Once we've recovered we need to consume the rest of the message
         -- string so that parsing can continue beyond it.

--- a/lib/Intlc/Parser/JSON.hs
+++ b/lib/Intlc/Parser/JSON.hs
@@ -59,7 +59,7 @@ translation = obj $ intercalateEffect objSep $ Translation
 msg :: Parser ICU.Message
 msg = lift $ withRecovery recover p
   where p = runReaderT (char '"' *> ICUP.msg) icupState
-        icupState = ICUP.initialState { ICUP.endOfInput = void $ char '"' }
+        icupState = ICUP.emptyState { ICUP.endOfInput = void $ char '"' }
         recover e = error "absurd" <$ consume <* registerParseError e
         -- Once we've recovered we need to consume the rest of the message
         -- string so that parsing can continue beyond it.

--- a/test/Intlc/EndToEndSpec.hs
+++ b/test/Intlc/EndToEndSpec.hs
@@ -6,7 +6,7 @@ import           Intlc.Compiler             (compileDataset, expandPlurals)
 import           Intlc.Core                 (Locale (Locale))
 import           Intlc.Parser               (parseDataset)
 import           Intlc.Parser.Error         (ParseFailure)
-import           Intlc.Parser.ICU           (msg, initialState, ParserState (endOfInput))
+import           Intlc.Parser.ICU           (msg, emptyState, ParserState (endOfInput))
 import           Prelude
 import           System.FilePath            ((<.>), (</>))
 import           Test.Hspec
@@ -19,7 +19,7 @@ parseAndCompileDataset = compileDataset (Locale "en-US") <=< first (pure . show)
 
 parseAndExpandMsg :: Text -> Either ParseFailure Text
 parseAndExpandMsg = fmap (compileMsg . expandPlurals) . parseMsg
-  where parseMsg = runParser (runReaderT msg (initialState { endOfInput = eof })) "test"
+  where parseMsg = runParser (runReaderT msg (emptyState { endOfInput = eof })) "test"
 
 golden :: String -> Text -> Golden String
 golden name in' = baseCfg

--- a/test/Intlc/EndToEndSpec.hs
+++ b/test/Intlc/EndToEndSpec.hs
@@ -6,7 +6,7 @@ import           Intlc.Compiler             (compileDataset, expandPlurals)
 import           Intlc.Core                 (Locale (Locale))
 import           Intlc.Parser               (parseDataset)
 import           Intlc.Parser.Error         (ParseFailure)
-import           Intlc.Parser.ICU           (ParserState (ParserState), msg)
+import           Intlc.Parser.ICU           (msg, initialState)
 import           Prelude
 import           System.FilePath            ((<.>), (</>))
 import           Test.Hspec
@@ -19,7 +19,7 @@ parseAndCompileDataset = compileDataset (Locale "en-US") <=< first (pure . show)
 
 parseAndExpandMsg :: Text -> Either ParseFailure Text
 parseAndExpandMsg = fmap (compileMsg . expandPlurals) . parseMsg
-  where parseMsg = runParser (runReaderT msg (ParserState mempty)) "test"
+  where parseMsg = runParser (runReaderT msg initialState) "test"
 
 golden :: String -> Text -> Golden String
 golden name in' = baseCfg

--- a/test/Intlc/EndToEndSpec.hs
+++ b/test/Intlc/EndToEndSpec.hs
@@ -6,12 +6,12 @@ import           Intlc.Compiler             (compileDataset, expandPlurals)
 import           Intlc.Core                 (Locale (Locale))
 import           Intlc.Parser               (parseDataset)
 import           Intlc.Parser.Error         (ParseFailure)
-import           Intlc.Parser.ICU           (msg, initialState)
+import           Intlc.Parser.ICU           (msg, initialState, ParserState (endOfInput))
 import           Prelude
 import           System.FilePath            ((<.>), (</>))
 import           Test.Hspec
 import           Test.Hspec.Golden          (Golden (..), defaultGolden)
-import           Text.Megaparsec            (runParser)
+import           Text.Megaparsec            (runParser, eof)
 import           Text.RawString.QQ          (r)
 
 parseAndCompileDataset :: Text -> Either (NonEmpty Text) Text
@@ -19,7 +19,7 @@ parseAndCompileDataset = compileDataset (Locale "en-US") <=< first (pure . show)
 
 parseAndExpandMsg :: Text -> Either ParseFailure Text
 parseAndExpandMsg = fmap (compileMsg . expandPlurals) . parseMsg
-  where parseMsg = runParser (runReaderT msg initialState) "test"
+  where parseMsg = runParser (runReaderT msg (initialState { endOfInput = eof })) "test"
 
 golden :: String -> Text -> Golden String
 golden name in' = baseCfg

--- a/test/Intlc/Parser/ICUSpec.hs
+++ b/test/Intlc/Parser/ICUSpec.hs
@@ -6,7 +6,7 @@ import           Intlc.Parser.Error    (MessageParseErr (..),
 import           Intlc.Parser.ICU
 import           Prelude
 import           Test.Hspec
-import           Test.Hspec.Megaparsec hiding (initialState)
+import           Test.Hspec.Megaparsec
 import           Text.Megaparsec       (runParser, eof)
 import           Text.Megaparsec.Error (ErrorFancy (ErrorCustom))
 
@@ -14,7 +14,7 @@ parseWith :: ParserState -> Parser a -> Text -> Either ParseFailure a
 parseWith s p = runParser (runReaderT p s) "test"
 
 parse :: Parser a -> Text -> Either ParseFailure a
-parse = parseWith $ initialState { endOfInput = eof }
+parse = parseWith $ emptyState { endOfInput = eof }
 
 spec :: Spec
 spec = describe "ICU parser" $ do
@@ -163,7 +163,7 @@ spec = describe "ICU parser" $ do
       parse cardinalPluralCases `shouldSucceedOn` "=0 {foo} =1 {bar}"
 
     it "parses literal and plural cases, wildcard, and interpolation token" $ do
-      parseWith (initialState { pluralCtxName = Just "xyz" }) cardinalPluralCases "=0 {foo} few {bar} other {baz #}" `shouldParse`
+      parseWith (emptyState { pluralCtxName = Just "xyz" }) cardinalPluralCases "=0 {foo} few {bar} other {baz #}" `shouldParse`
         Cardinal (MixedPlural (pure $ PluralCase (PluralExact "0") [Plaintext "foo"]) (pure $ PluralCase Few [Plaintext "bar"]) (PluralWildcard [Plaintext "baz ", Interpolation "xyz" PluralRef]))
 
   describe "selectordinal" $ do
@@ -184,7 +184,7 @@ spec = describe "ICU parser" $ do
       parse ordinalPluralCases `shouldSucceedOn` "=0 {foo} one {bar} other {baz}"
 
     it "parses literal and plural cases, wildcard, and interpolation token" $ do
-      parseWith (initialState { pluralCtxName = Just "xyz" }) cardinalPluralCases "=0 {foo} few {bar} other {baz #}" `shouldParse`
+      parseWith (emptyState { pluralCtxName = Just "xyz" }) cardinalPluralCases "=0 {foo} few {bar} other {baz #}" `shouldParse`
         Cardinal (MixedPlural (pure $ PluralCase (PluralExact "0") [Plaintext "foo"]) (pure $ PluralCase Few [Plaintext "bar"]) (PluralWildcard [Plaintext "baz ", Interpolation "xyz" PluralRef]))
 
   describe "select" $ do

--- a/test/Intlc/Parser/ICUSpec.hs
+++ b/test/Intlc/Parser/ICUSpec.hs
@@ -7,14 +7,14 @@ import           Intlc.Parser.ICU
 import           Prelude
 import           Test.Hspec
 import           Test.Hspec.Megaparsec hiding (initialState)
-import           Text.Megaparsec       (runParser)
+import           Text.Megaparsec       (runParser, eof)
 import           Text.Megaparsec.Error (ErrorFancy (ErrorCustom))
 
 parseWith :: ParserState -> Parser a -> Text -> Either ParseFailure a
 parseWith s p = runParser (runReaderT p s) "test"
 
 parse :: Parser a -> Text -> Either ParseFailure a
-parse = parseWith initialState
+parse = parseWith $ initialState { endOfInput = eof }
 
 spec :: Spec
 spec = describe "ICU parser" $ do
@@ -163,7 +163,7 @@ spec = describe "ICU parser" $ do
       parse cardinalPluralCases `shouldSucceedOn` "=0 {foo} =1 {bar}"
 
     it "parses literal and plural cases, wildcard, and interpolation token" $ do
-      parseWith (ParserState (Just "xyz")) cardinalPluralCases "=0 {foo} few {bar} other {baz #}" `shouldParse`
+      parseWith (initialState { pluralCtxName = Just "xyz" }) cardinalPluralCases "=0 {foo} few {bar} other {baz #}" `shouldParse`
         Cardinal (MixedPlural (pure $ PluralCase (PluralExact "0") [Plaintext "foo"]) (pure $ PluralCase Few [Plaintext "bar"]) (PluralWildcard [Plaintext "baz ", Interpolation "xyz" PluralRef]))
 
   describe "selectordinal" $ do
@@ -184,7 +184,7 @@ spec = describe "ICU parser" $ do
       parse ordinalPluralCases `shouldSucceedOn` "=0 {foo} one {bar} other {baz}"
 
     it "parses literal and plural cases, wildcard, and interpolation token" $ do
-      parseWith (ParserState (Just "xyz")) cardinalPluralCases "=0 {foo} few {bar} other {baz #}" `shouldParse`
+      parseWith (initialState { pluralCtxName = Just "xyz" }) cardinalPluralCases "=0 {foo} few {bar} other {baz #}" `shouldParse`
         Cardinal (MixedPlural (pure $ PluralCase (PluralExact "0") [Plaintext "foo"]) (pure $ PluralCase Few [Plaintext "bar"]) (PluralWildcard [Plaintext "baz ", Interpolation "xyz" PluralRef]))
 
   describe "select" $ do

--- a/test/Intlc/Parser/ICUSpec.hs
+++ b/test/Intlc/Parser/ICUSpec.hs
@@ -81,6 +81,9 @@ spec = describe "ICU parser" $ do
           Message [Plaintext "a ", Interpolation "b" String, Plaintext " {c} ", Interpolation "d" String, Plaintext " e"]
         parse msg "a {b} 'c {d} e" `shouldParse`
           Message [Plaintext "a ", Interpolation "b" String, Plaintext " 'c ", Interpolation "d" String, Plaintext " e"]
+        parse msg "{n, plural, =42 {# '#}}" `shouldParse`
+          let xs = [Interpolation "n" PluralRef, Plaintext " #"]
+           in Message [Interpolation "n" $ Plural (Cardinal $ LitPlural (pure $ PluralCase (PluralExact "42") xs) Nothing)]
 
       it "escapes two single quotes as one single quote" $ do
         parse msg "This '{isn''t}' obvious." `shouldParse` Message [Plaintext "This {isn't} obvious."]

--- a/test/Intlc/Parser/ICUSpec.hs
+++ b/test/Intlc/Parser/ICUSpec.hs
@@ -89,6 +89,7 @@ spec = describe "ICU parser" $ do
 
       it "ignores one single quote not immediately preceding a syntax character" $ do
         parse msg "'" `shouldParse` Message [Plaintext "'"]
+        parse msg "' '" `shouldParse` Message [Plaintext "' '"]
         parse msg "x'y" `shouldParse` Message [Plaintext "x'y"]
 
   describe "interpolation" $ do

--- a/test/Intlc/Parser/JSONSpec.hs
+++ b/test/Intlc/Parser/JSONSpec.hs
@@ -6,7 +6,7 @@ import           Intlc.Parser.Error    (JSONParseErr (..), MessageParseErr (..),
                                         ParseErr (..), ParseFailure)
 import           Prelude
 import           Test.Hspec
-import           Test.Hspec.Megaparsec hiding (initialState)
+import           Test.Hspec.Megaparsec
 import           Text.Megaparsec       (ErrorFancy (ErrorCustom), ParseError)
 import           Text.RawString.QQ     (r)
 import qualified Intlc.ICU as ICU

--- a/test/Intlc/Parser/JSONSpec.hs
+++ b/test/Intlc/Parser/JSONSpec.hs
@@ -90,3 +90,11 @@ spec = describe "JSON parser" $ do
       [ ("x", msg [ICU.Plaintext "a'"])
       , ("y", msg [ICU.Plaintext "'b"])
       ]
+
+    parse [r|{
+      "x": { "message": "a'{b" },
+      "y": { "message": "c}'d" }
+    }|] `shouldParse` fromList
+      [ ("x", msg [ICU.Plaintext "a{b"])
+      , ("y", msg [ICU.Plaintext "c}'d"])
+      ]


### PR DESCRIPTION
Fixes #147. Review by commit for context.

Additionally improves compliance with ICU spec and support for formats other than JSON with respect to the ICU parser.