### PR TITLE
Revert "Disable CI formatting"

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -46,17 +46,16 @@ jobs:
       - uses: haskell/actions/hlint-run@v2
         with:
           path: '["lib/", "cli/", "internal/"]'
-  # # Broken, see: https://github.com/unsplash/intlc/issues/151
-  # fmt:
-  #   name: Formatting
-  #   runs-on: ubuntu-latest
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     # stylish-haskell doesn't have a check/dry run option, so we'll run it
-  #     # against files in place and test if there are any diffs with Git.
-  #     - run: |
-  #         curl -sL https://raw.github.com/haskell/stylish-haskell/master/scripts/latest.sh | sh -s 'lib/ src/ test/ -ri'
-  #         git diff-index --exit-code HEAD
+  fmt:
+    name: Formatting
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      # stylish-haskell doesn't have a check/dry run option, so we'll run it
+      # against files in place and test if there are any diffs with Git.
+      - run: |
+          curl -sL https://raw.github.com/haskell/stylish-haskell/master/scripts/latest.sh | sh -s 'lib/ src/ test/ -ri'
+          git diff-index --exit-code HEAD
   typecheck-ts:
     name: Typecheck TypeScript
     runs-on: ubuntu-latest


### PR DESCRIPTION
This reverts commit bf6bc0c206f794e34d17b71d5c0cef71a72b0843.

It seems to be working again. /shrug

Closes #151.