### PR TITLE
 Allow plural lone wildcard

### DIFF
--- a/lib/Intlc/Backend/ICU/Compiler.hs
+++ b/lib/Intlc/Backend/ICU/Compiler.hs
@@ -41,9 +41,8 @@ dateTimeFmt Long   = "long"
 dateTimeFmt Full   = "full"
 
 cardinalPlural :: CardinalPlural -> Text
-cardinalPlural (LitPlural xs mw)     = unwords $ toList (exactPluralCase <$> xs) <> foldMap (pure . pluralWildcard) mw
-cardinalPlural (RulePlural xs w)     = unwords . toList $ (rulePluralCase <$> xs) <> pure (pluralWildcard w)
-cardinalPlural (MixedPlural xs ys w) = unwords . toList $ (exactPluralCase <$> xs) <> (rulePluralCase <$> ys) <> pure (pluralWildcard w)
+cardinalPlural (CardinalExact xs)        = unwords . toList . fmap exactPluralCase $ xs
+cardinalPlural (CardinalInexact xs ys w) = unwords . mconcat $ [exactPluralCase <$> xs, rulePluralCase <$> ys, pure $ pluralWildcard w]
 
 ordinalPlural :: OrdinalPlural -> Text
 ordinalPlural (OrdinalPlural xs ys w) = unwords $

--- a/lib/Intlc/Backend/ICU/Compiler.hs
+++ b/lib/Intlc/Backend/ICU/Compiler.hs
@@ -46,7 +46,7 @@ cardinalPlural (CardinalInexact xs ys w) = unwords . mconcat $ [exactPluralCase 
 
 ordinalPlural :: OrdinalPlural -> Text
 ordinalPlural (OrdinalPlural xs ys w) = unwords $
-  (exactPluralCase <$> xs) <> (rulePluralCase <$> toList ys) <> pure (pluralWildcard w)
+  (exactPluralCase <$> xs) <> (rulePluralCase <$> ys) <> pure (pluralWildcard w)
 
 exactPluralCase :: PluralCase PluralExact -> Text
 exactPluralCase (PluralCase (PluralExact n) xs) = "=" <> n <> " {" <> stream xs <> "}"

--- a/lib/Intlc/Backend/JavaScript/Language.hs
+++ b/lib/Intlc/Backend/JavaScript/Language.hs
@@ -79,18 +79,18 @@ fromInterp nraw t =
 
 fromPlural :: Ref -> ICU.Plural -> ASTCompiler Match
 fromPlural r p = case p of
-  ICU.Cardinal (ICU.CardinalExact lcs)              -> Match r LitCond . LitMatchRet <$> (fromExactPluralCase `mapM` lcs)
-  ICU.Cardinal (ICU.CardinalInexact lcs [] w)       -> Match r LitCond <$> ret
+  ICU.CardinalExact lcs              -> Match r LitCond . LitMatchRet <$> (fromExactPluralCase `mapM` lcs)
+  ICU.CardinalInexact lcs [] w       -> Match r LitCond <$> ret
     where ret = NonLitMatchRet <$> (fromExactPluralCase `mapM` lcs) <*> fromPluralWildcard w
-  ICU.Cardinal (ICU.CardinalInexact [] rcs w)       -> Match r CardinalPluralRuleCond <$> ret
+  ICU.CardinalInexact [] rcs w       -> Match r CardinalPluralRuleCond <$> ret
     where ret = NonLitMatchRet <$> (fromRulePluralCase `mapM` rcs) <*> fromPluralWildcard w
-  ICU.Cardinal (ICU.CardinalInexact (lc:lcs) rcs w) -> Match r LitCond <$> litRet
+  ICU.CardinalInexact (lc:lcs) rcs w -> Match r LitCond <$> litRet
     where litRet = RecMatchRet <$> (fromExactPluralCase `mapM` lcs') <*> (Match r CardinalPluralRuleCond <$> ruleRet)
           ruleRet = NonLitMatchRet <$> (fromRulePluralCase `mapM` rcs) <*> fromPluralWildcard w
           lcs' = lc :| lcs
-  ICU.Ordinal (ICU.OrdinalPlural [] rcs w)          -> Match r OrdinalPluralRuleCond <$> m
+  ICU.Ordinal [] rcs w               -> Match r OrdinalPluralRuleCond <$> m
     where m = NonLitMatchRet <$> (fromRulePluralCase `mapM` rcs) <*> fromPluralWildcard w
-  ICU.Ordinal (ICU.OrdinalPlural (lc:lcs) rcs w)    -> Match r LitCond <$> m
+  ICU.Ordinal (lc:lcs) rcs w         -> Match r LitCond <$> m
     where m = RecMatchRet <$> ((:|) <$> fromExactPluralCase lc <*> (fromExactPluralCase `mapM` lcs)) <*> im
           im = Match r OrdinalPluralRuleCond <$> (NonLitMatchRet <$> (fromRulePluralCase `mapM` rcs) <*> fromPluralWildcard w)
 

--- a/lib/Intlc/Backend/JavaScript/Language.hs
+++ b/lib/Intlc/Backend/JavaScript/Language.hs
@@ -89,10 +89,10 @@ fromPlural r p = case p of
           ruleRet = NonLitMatchRet <$> (fromRulePluralCase `mapM` rcs) <*> fromPluralWildcard w
           lcs' = lc :| lcs
   ICU.Ordinal (ICU.OrdinalPlural [] rcs w)          -> Match r OrdinalPluralRuleCond <$> m
-    where m = NonLitMatchRet <$> (toList <$> fromRulePluralCase `mapM` rcs) <*> fromPluralWildcard w
+    where m = NonLitMatchRet <$> (fromRulePluralCase `mapM` rcs) <*> fromPluralWildcard w
   ICU.Ordinal (ICU.OrdinalPlural (lc:lcs) rcs w)    -> Match r LitCond <$> m
     where m = RecMatchRet <$> ((:|) <$> fromExactPluralCase lc <*> (fromExactPluralCase `mapM` lcs)) <*> im
-          im = Match r OrdinalPluralRuleCond <$> (NonLitMatchRet <$> (toList <$> fromRulePluralCase `mapM` rcs) <*> fromPluralWildcard w)
+          im = Match r OrdinalPluralRuleCond <$> (NonLitMatchRet <$> (fromRulePluralCase `mapM` rcs) <*> fromPluralWildcard w)
 
 fromExactPluralCase :: ICU.PluralCase ICU.PluralExact -> ASTCompiler Branch
 fromExactPluralCase (ICU.PluralCase (ICU.PluralExact n) xs) = Branch n <$> (fromToken `mapM` xs)

--- a/lib/Intlc/Backend/TypeScript/Language.hs
+++ b/lib/Intlc/Backend/TypeScript/Language.hs
@@ -68,11 +68,11 @@ fromInterp n (ICU.Callback xs) = (n, TEndo) : (fromToken =<< xs)
 fromPlural :: Text -> ICU.Plural -> UncollatedArgs
 -- We can compile exact cardinal plurals (i.e. those without a wildcard) to a
 -- union of number literals.
-fromPlural n (ICU.Cardinal (ICU.CardinalExact ls))        = (n, t) : (fromExactPluralCase =<< toList ls)
+fromPlural n (ICU.CardinalExact ls)        = (n, t) : (fromExactPluralCase =<< toList ls)
   where t = TNumLitUnion $ caseLit <$> ls
         caseLit (ICU.PluralCase (ICU.PluralExact x) _) = x
-fromPlural n (ICU.Cardinal (ICU.CardinalInexact ls rs w)) = (n, TNum) : (fromExactPluralCase =<< ls) <> (fromRulePluralCase =<< rs) <> fromPluralWildcard w
-fromPlural n (ICU.Ordinal (ICU.OrdinalPlural ls rs w))    = (n, TNum) : (fromExactPluralCase =<< ls) <> (fromRulePluralCase =<< rs) <> fromPluralWildcard w
+fromPlural n (ICU.CardinalInexact ls rs w) = (n, TNum) : (fromExactPluralCase =<< ls) <> (fromRulePluralCase =<< rs) <> fromPluralWildcard w
+fromPlural n (ICU.Ordinal ls rs w)         = (n, TNum) : (fromExactPluralCase =<< ls) <> (fromRulePluralCase =<< rs) <> fromPluralWildcard w
 
 fromExactPluralCase :: ICU.PluralCase ICU.PluralExact -> UncollatedArgs
 fromExactPluralCase (ICU.PluralCase (ICU.PluralExact _) xs) = fromToken =<< xs

--- a/lib/Intlc/Backend/TypeScript/Language.hs
+++ b/lib/Intlc/Backend/TypeScript/Language.hs
@@ -71,8 +71,8 @@ fromPlural :: Text -> ICU.Plural -> UncollatedArgs
 fromPlural n (ICU.Cardinal (ICU.CardinalExact ls))        = (n, t) : (fromExactPluralCase =<< toList ls)
   where t = TNumLitUnion $ caseLit <$> ls
         caseLit (ICU.PluralCase (ICU.PluralExact x) _) = x
-fromPlural n (ICU.Cardinal (ICU.CardinalInexact ls rs w)) = (n, TNum) : (fromExactPluralCase =<< ls) <> (fromRulePluralCase =<< toList rs) <> fromPluralWildcard w
-fromPlural n (ICU.Ordinal (ICU.OrdinalPlural ls rs w))    = (n, TNum) : (fromExactPluralCase =<< ls) <> (fromRulePluralCase =<< toList rs) <> fromPluralWildcard w
+fromPlural n (ICU.Cardinal (ICU.CardinalInexact ls rs w)) = (n, TNum) : (fromExactPluralCase =<< ls) <> (fromRulePluralCase =<< rs) <> fromPluralWildcard w
+fromPlural n (ICU.Ordinal (ICU.OrdinalPlural ls rs w))    = (n, TNum) : (fromExactPluralCase =<< ls) <> (fromRulePluralCase =<< rs) <> fromPluralWildcard w
 
 fromExactPluralCase :: ICU.PluralCase ICU.PluralExact -> UncollatedArgs
 fromExactPluralCase (ICU.PluralCase (ICU.PluralExact _) xs) = fromToken =<< xs

--- a/lib/Intlc/Compiler.hs
+++ b/lib/Intlc/Compiler.hs
@@ -89,7 +89,7 @@ expandPlurals (ICU.Message xs) = ICU.Message . flip mapTokens xs $ \case
     ICU.Cardinal (ICU.CardinalInexact exacts rules w) ->
       ICU.Cardinal $ ICU.CardinalInexact exacts (toList $ expandRules rules w) w
     ICU.Ordinal (ICU.OrdinalPlural exacts rules w) ->
-      ICU.Ordinal $ ICU.OrdinalPlural exacts (expandRules rules w) w
+      ICU.Ordinal $ ICU.OrdinalPlural exacts (toList $ expandRules rules w) w
   x -> x
 
 expandRules :: (Functor f, Foldable f) => f (ICU.PluralCase ICU.PluralRule) -> ICU.PluralWildcard -> NonEmpty (ICU.PluralCase ICU.PluralRule)

--- a/lib/Intlc/ICU.hs
+++ b/lib/Intlc/ICU.hs
@@ -59,12 +59,11 @@ data CardinalPlural
   | CardinalInexact [PluralCase PluralExact] [PluralCase PluralRule] PluralWildcard
   deriving (Show, Eq)
 
--- | Ordinal plurals require at least one rule case and therefore also a
--- wildcard. An ordinal plural without a rule case would make the use of this
--- construct redundant, and in such cases the consumer should instead use a
--- cardinal plural.
+-- | Ordinal plurals always require a wildcard as per their intended usage with
+-- rules, however as with the cardinal plural type we'll allow a wider set of
+-- suboptimal usages that we can then lint against.
 data OrdinalPlural
-  = OrdinalPlural [PluralCase PluralExact] (NonEmpty (PluralCase PluralRule)) PluralWildcard
+  = OrdinalPlural [PluralCase PluralExact] [PluralCase PluralRule] PluralWildcard
   deriving (Show, Eq)
 
 data PluralCase a = PluralCase a Stream

--- a/lib/Intlc/Parser/ICU.hs
+++ b/lib/Intlc/Parser/ICU.hs
@@ -170,12 +170,12 @@ selectCases = choice
         wildcardName = "other"
 
 cardinalPluralCases :: Parser Plural
-cardinalPluralCases = fmap Cardinal . tryClassify =<< p
+cardinalPluralCases = tryClassify =<< p
     where tryClassify = maybe empty pure . uncurry classifyCardinal
           p = (,) <$> disorderedPluralCases <*> optional pluralWildcard
 
 ordinalPluralCases :: Parser Plural
-ordinalPluralCases = fmap Ordinal . tryClassify =<< p
+ordinalPluralCases = tryClassify =<< p
     where tryClassify = maybe empty pure . uncurry classifyOrdinal
           p = (,) <$> disorderedPluralCases <*> pluralWildcard
 
@@ -206,7 +206,7 @@ pluralWildcard :: Parser PluralWildcard
 pluralWildcard = PluralWildcard <$> (string "other" *> hspace1 *> caseBody)
 
 -- | To simplify parsing cases we validate after-the-fact here.
-classifyCardinal :: Foldable f => f ParsedPluralCase -> Maybe PluralWildcard -> Maybe CardinalPlural
+classifyCardinal :: Foldable f => f ParsedPluralCase -> Maybe PluralWildcard -> Maybe Plural
 classifyCardinal xs mw = case (organisePluralCases xs, mw) of
   ((l:ls, []), Nothing) -> Just (CardinalExact (l:|ls))
   ((ls, rs),   Just w)  -> Just (CardinalInexact ls rs w)
@@ -216,9 +216,9 @@ classifyCardinal xs mw = case (organisePluralCases xs, mw) of
 -- performed here to simplify supporting disordered cases in the parser
 -- (whereas validating the presence of a wildcard at the end is trivial in the
 -- parser).
-classifyOrdinal :: Foldable f => f ParsedPluralCase -> PluralWildcard -> Maybe OrdinalPlural
+classifyOrdinal :: Foldable f => f ParsedPluralCase -> PluralWildcard -> Maybe Plural
 classifyOrdinal xs w = case organisePluralCases xs of
-  (ls, r:rs) -> Just $ OrdinalPlural ls (r:rs) w
+  (ls, r:rs) -> Just $ Ordinal ls (r:rs) w
   _          -> Nothing
 
 organisePluralCases :: Foldable f => f ParsedPluralCase -> ([PluralCase PluralExact], [PluralCase PluralRule])

--- a/lib/Intlc/Parser/ICU.hs
+++ b/lib/Intlc/Parser/ICU.hs
@@ -184,8 +184,8 @@ data ParsedPluralCase
   = ParsedExact (PluralCase PluralExact)
   | ParsedRule (PluralCase PluralRule)
 
-disorderedPluralCases :: Parser (NonEmpty ParsedPluralCase)
-disorderedPluralCases = flip NE.sepEndBy1 hspace1 $ choice
+disorderedPluralCases :: Parser [ParsedPluralCase]
+disorderedPluralCases = flip sepEndBy hspace1 $ choice
   [ (ParsedExact .) . PluralCase <$> pluralExact <* hspace1 <*> caseBody
   , (ParsedRule .)  . PluralCase <$> pluralRule  <* hspace1 <*> caseBody
   ]

--- a/lib/Intlc/Parser/ICU.hs
+++ b/lib/Intlc/Parser/ICU.hs
@@ -218,8 +218,7 @@ classifyCardinal xs mw = case (organisePluralCases xs, mw) of
 -- parser).
 classifyOrdinal :: Foldable f => f ParsedPluralCase -> PluralWildcard -> Maybe Plural
 classifyOrdinal xs w = case organisePluralCases xs of
-  (ls, r:rs) -> Just $ Ordinal ls (r:rs) w
-  _          -> Nothing
+  (ls, rs) -> Just $ Ordinal ls rs w
 
 organisePluralCases :: Foldable f => f ParsedPluralCase -> ([PluralCase PluralExact], [PluralCase PluralRule])
 organisePluralCases = foldr f mempty

--- a/lib/Intlc/Parser/ICU.hs
+++ b/lib/Intlc/Parser/ICU.hs
@@ -218,7 +218,7 @@ classifyCardinal xs mw = case (organisePluralCases xs, mw) of
 -- parser).
 classifyOrdinal :: Foldable f => f ParsedPluralCase -> PluralWildcard -> Maybe OrdinalPlural
 classifyOrdinal xs w = case organisePluralCases xs of
-  (ls, r:rs) -> Just $ OrdinalPlural ls (r:|rs) w
+  (ls, r:rs) -> Just $ OrdinalPlural ls (r:rs) w
   _          -> Nothing
 
 organisePluralCases :: Foldable f => f ParsedPluralCase -> ([PluralCase PluralExact], [PluralCase PluralRule])

--- a/test/Intlc/Backend/TypeScriptSpec.hs
+++ b/test/Intlc/Backend/TypeScriptSpec.hs
@@ -36,7 +36,7 @@ spec = describe "TypeScript compiler" $ do
             ))
           , ICU.Plaintext "! You are "
           , ICU.Interpolation "age" (ICU.Plural (ICU.Cardinal
-              (ICU.MixedPlural
+              (ICU.CardinalInexact
               (pure (ICU.PluralCase (ICU.PluralExact "42") (pure (ICU.Plaintext "very cool"))))
               (pure (ICU.PluralCase ICU.Zero (pure (ICU.Plaintext "new around here"))))
               (ICU.PluralWildcard (pure (ICU.Plaintext "not all that interesting")))
@@ -115,7 +115,7 @@ spec = describe "TypeScript compiler" $ do
       fromToken x `shouldBe` fromArgs ys
 
     it "in cardinal plural" $ do
-      let x = ICU.Plural . ICU.Cardinal . flip ICU.LitPlural Nothing . pure $
+      let x = ICU.Plural . ICU.Cardinal . ICU.CardinalExact . pure $
                 ICU.PluralCase (ICU.PluralExact "42") [ICU.Interpolation "y" ICU.String]
       let ys =
               [ ("x", pure (TS.TNumLitUnion (pure "42")))

--- a/test/Intlc/Backend/TypeScriptSpec.hs
+++ b/test/Intlc/Backend/TypeScriptSpec.hs
@@ -35,13 +35,13 @@ spec = describe "TypeScript compiler" $ do
               ICU.Interpolation "name" ICU.String
             ))
           , ICU.Plaintext "! You are "
-          , ICU.Interpolation "age" (ICU.Plural (ICU.Cardinal
+          , ICU.Interpolation "age" (ICU.Plural
               (ICU.CardinalInexact
-              (pure (ICU.PluralCase (ICU.PluralExact "42") (pure (ICU.Plaintext "very cool"))))
-              (pure (ICU.PluralCase ICU.Zero (pure (ICU.Plaintext "new around here"))))
-              (ICU.PluralWildcard (pure (ICU.Plaintext "not all that interesting")))
+                (pure (ICU.PluralCase (ICU.PluralExact "42") (pure (ICU.Plaintext "very cool"))))
+                (pure (ICU.PluralCase ICU.Zero (pure (ICU.Plaintext "new around here"))))
+                (ICU.PluralWildcard (pure (ICU.Plaintext "not all that interesting")))
               )
-            ))
+            )
           , ICU.Plaintext ". Regardless, the magic number is most certainly "
           , ICU.Interpolation "magicNumber" ICU.Number
           , ICU.Plaintext "! The date is "
@@ -115,7 +115,7 @@ spec = describe "TypeScript compiler" $ do
       fromToken x `shouldBe` fromArgs ys
 
     it "in cardinal plural" $ do
-      let x = ICU.Plural . ICU.Cardinal . ICU.CardinalExact . pure $
+      let x = ICU.Plural . ICU.CardinalExact . pure $
                 ICU.PluralCase (ICU.PluralExact "42") [ICU.Interpolation "y" ICU.String]
       let ys =
               [ ("x", pure (TS.TNumLitUnion (pure "42")))
@@ -124,7 +124,7 @@ spec = describe "TypeScript compiler" $ do
       fromToken x `shouldBe` fromArgs ys
 
     it "in ordinal plural" $ do
-      let x = ICU.Plural . ICU.Ordinal $ ICU.OrdinalPlural
+      let x = ICU.Plural $ ICU.Ordinal
                 [ICU.PluralCase (ICU.PluralExact "42") [ICU.Interpolation "foo" (ICU.Date ICU.Short)]]
                 (pure $ ICU.PluralCase ICU.Few [ICU.Interpolation "bar" ICU.String])
                 (ICU.PluralWildcard [ICU.Interpolation "baz" ICU.Number])

--- a/test/Intlc/CompilerSpec.hs
+++ b/test/Intlc/CompilerSpec.hs
@@ -63,13 +63,13 @@ spec = describe "compiler" $ do
       let one = PluralCase One [Plaintext "a dog"]
       let onef = PluralCase One [Plaintext "I have a dog"]
 
-      flatten (Message [Plaintext "I have ", Interpolation "count" (Plural (Cardinal (CardinalInexact [] (pure one) other)))]) `shouldBe`
-        Message (pure $ Interpolation "count" (Plural (Cardinal (CardinalInexact [] (pure onef) otherf))))
+      flatten (Message [Plaintext "I have ", Interpolation "count" (Plural (CardinalInexact [] (pure one) other))]) `shouldBe`
+        Message (pure $ Interpolation "count" (Plural (CardinalInexact [] (pure onef) otherf)))
 
     it "flattens deep interpolations" $ do
-      let x = Message $
+      let x = Message
             [ Plaintext "I have "
-            , Interpolation "count" . Plural . Cardinal $ CardinalInexact
+            , Interpolation "count" . Plural $ CardinalInexact
               []
               (pure $ PluralCase One [Plaintext "a dog"])
               (PluralWildcard
@@ -83,7 +83,7 @@ spec = describe "compiler" $ do
             , Plaintext "!"
             ]
       let y = Message . pure $
-            Interpolation "count" . Plural . Cardinal $ CardinalInexact
+            Interpolation "count" . Plural $ CardinalInexact
               []
               (pure $ PluralCase One [Plaintext "I have a dog!"])
               (PluralWildcard
@@ -133,4 +133,4 @@ spec = describe "compiler" $ do
       let c x y = PluralCase x [Plaintext y]
       let xs = [c Two "foo", c Many "", c Zero "bar", c One "baz", c Few ""]
 
-      flip f (PluralWildcard [Plaintext "any"]) xs `shouldBe` (fromList xs)
+      f xs (PluralWildcard [Plaintext "any"]) `shouldBe` fromList xs

--- a/test/Intlc/CompilerSpec.hs
+++ b/test/Intlc/CompilerSpec.hs
@@ -63,13 +63,14 @@ spec = describe "compiler" $ do
       let one = PluralCase One [Plaintext "a dog"]
       let onef = PluralCase One [Plaintext "I have a dog"]
 
-      flatten (Message [Plaintext "I have ", Interpolation "count" (Plural (Cardinal (RulePlural (pure one) other)))]) `shouldBe`
-        Message (pure $ Interpolation "count" (Plural (Cardinal (RulePlural (pure onef) otherf))))
+      flatten (Message [Plaintext "I have ", Interpolation "count" (Plural (Cardinal (CardinalInexact [] (pure one) other)))]) `shouldBe`
+        Message (pure $ Interpolation "count" (Plural (Cardinal (CardinalInexact [] (pure onef) otherf))))
 
     it "flattens deep interpolations" $ do
       let x = Message $
             [ Plaintext "I have "
-            , Interpolation "count" . Plural . Cardinal $ RulePlural
+            , Interpolation "count" . Plural . Cardinal $ CardinalInexact
+              []
               (pure $ PluralCase One [Plaintext "a dog"])
               (PluralWildcard
                 [ Interpolation "count" Number
@@ -82,7 +83,8 @@ spec = describe "compiler" $ do
             , Plaintext "!"
             ]
       let y = Message . pure $
-            Interpolation "count" . Plural . Cardinal $ RulePlural
+            Interpolation "count" . Plural . Cardinal $ CardinalInexact
+              []
               (pure $ PluralCase One [Plaintext "I have a dog!"])
               (PluralWildcard
                 [ Interpolation "name" . Select $ These

--- a/test/Intlc/LinterSpec.hs
+++ b/test/Intlc/LinterSpec.hs
@@ -66,7 +66,7 @@ spec = describe "linter" $ do
         let cb = Callback []
         lint (Message [Interpolation "x" cb, Interpolation "y" cb]) `shouldBe` Success
 
-        let p = Plural . Ordinal $ OrdinalPlural [] (pure $ PluralCase Zero []) (PluralWildcard [])
+        let p = Plural $ Ordinal [] (pure $ PluralCase Zero []) (PluralWildcard [])
         lint (Message [Interpolation "x" p, Interpolation "y" p]) `shouldBe` Success
 
       it "does not lint streams with 2 or more complex interpolations" $ do

--- a/test/Intlc/Parser/ICUSpec.hs
+++ b/test/Intlc/Parser/ICUSpec.hs
@@ -42,23 +42,23 @@ spec = describe "ICU parser" $ do
       it "parses as arg inside shallow plural" $ do
         let n = pure $ Interpolation "n" PluralRef
         parse msg "{n, plural, one {#} other {#}}" `shouldParse`
-          (Message . pure . Interpolation "n" . Plural . Cardinal $
+          (Message . pure . Interpolation "n" . Plural $
             CardinalInexact [] (pure $ PluralCase One n) (PluralWildcard n))
 
       it "parses as nearest arg inside deep plural" $ do
         let n = pure $ Interpolation "n" PluralRef
         let i = pure $ Interpolation "i" PluralRef
         parse msg "{n, plural, one {{i, plural, one {#} other {#}}} other {#}}" `shouldParse`
-          (Message . pure . Interpolation "n" . Plural . Cardinal $
+          (Message . pure . Interpolation "n" . Plural $
             CardinalInexact [] (pure $ PluralCase One (
-              pure . Interpolation "i" . Plural . Cardinal $
+              pure . Interpolation "i" . Plural $
                 CardinalInexact [] (pure $ PluralCase One i) (PluralWildcard i)
             )) (PluralWildcard n))
 
       it "parses as arg nested inside other interpolation" $ do
         let n = pure $ Interpolation "n" PluralRef
         parse msg "{n, plural, one {<f>#</f>} other {#}}" `shouldParse`
-          (Message . pure . Interpolation "n" . Plural . Cardinal $
+          (Message . pure . Interpolation "n" . Plural $
             CardinalInexact [] (pure $ PluralCase One (
               pure . Interpolation "f" . Callback $ n
             )) (PluralWildcard n))
@@ -84,7 +84,7 @@ spec = describe "ICU parser" $ do
           Message [Plaintext "a ", Interpolation "b" String, Plaintext " 'c ", Interpolation "d" String, Plaintext " e"]
         parse msg "{n, plural, =42 {# '#}}" `shouldParse`
           let xs = [Interpolation "n" PluralRef, Plaintext " #"]
-           in Message [Interpolation "n" $ Plural (Cardinal $ CardinalExact (pure $ PluralCase (PluralExact "42") xs))]
+           in Message [Interpolation "n" $ Plural (CardinalExact (pure $ PluralCase (PluralExact "42") xs))]
 
       it "escapes two single quotes as one single quote" $ do
         parse msg "This '{isn''t}' obvious." `shouldParse` Message [Plaintext "This {isn't} obvious."]
@@ -171,7 +171,7 @@ spec = describe "ICU parser" $ do
 
     it "parses literal and plural cases, wildcard, and interpolation token" $ do
       parseWith (emptyState { pluralCtxName = Just "xyz" }) cardinalPluralCases "=0 {foo} few {bar} other {baz #}" `shouldParse`
-        Cardinal (CardinalInexact (pure $ PluralCase (PluralExact "0") [Plaintext "foo"]) (pure $ PluralCase Few [Plaintext "bar"]) (PluralWildcard [Plaintext "baz ", Interpolation "xyz" PluralRef]))
+        CardinalInexact (pure $ PluralCase (PluralExact "0") [Plaintext "foo"]) (pure $ PluralCase Few [Plaintext "bar"]) (PluralWildcard [Plaintext "baz ", Interpolation "xyz" PluralRef])
 
   describe "selectordinal" $ do
     it "disallows wildcard not at the end" $ do
@@ -192,7 +192,7 @@ spec = describe "ICU parser" $ do
 
     it "parses literal and plural cases, wildcard, and interpolation token" $ do
       parseWith (emptyState { pluralCtxName = Just "xyz" }) cardinalPluralCases "=0 {foo} few {bar} other {baz #}" `shouldParse`
-        Cardinal (CardinalInexact (pure $ PluralCase (PluralExact "0") [Plaintext "foo"]) (pure $ PluralCase Few [Plaintext "bar"]) (PluralWildcard [Plaintext "baz ", Interpolation "xyz" PluralRef]))
+        CardinalInexact (pure $ PluralCase (PluralExact "0") [Plaintext "foo"]) (pure $ PluralCase Few [Plaintext "bar"]) (PluralWildcard [Plaintext "baz ", Interpolation "xyz" PluralRef])
 
   describe "select" $ do
     let selectCases' = selectCases <* eof

--- a/test/Intlc/Parser/ICUSpec.hs
+++ b/test/Intlc/Parser/ICUSpec.hs
@@ -152,25 +152,25 @@ spec = describe "ICU parser" $ do
       parse callback `shouldFailOn` "<x y></x y>"
 
   describe "plural" $ do
-    let cardinalPluralCases' = cardinalPluralCases <* eof
+    let cardinalCases' = cardinalCases <* eof
 
     it "disallows wildcard not at the end" $ do
-      parse cardinalPluralCases' `shouldSucceedOn` "=1 {foo} other {bar}"
-      parse cardinalPluralCases' `shouldFailOn` "other {bar} =1 {foo}"
+      parse cardinalCases' `shouldSucceedOn` "=1 {foo} other {bar}"
+      parse cardinalCases' `shouldFailOn` "other {bar} =1 {foo}"
 
     it "tolerates empty cases" $ do
-      parse cardinalPluralCases' `shouldSucceedOn` "=1 {} other {}"
+      parse cardinalCases' `shouldSucceedOn` "=1 {} other {}"
 
     it "tolerates no non-wildcard cases" $ do
-      parse cardinalPluralCases' `shouldSucceedOn` "other {foo}"
+      parse cardinalCases' `shouldSucceedOn` "other {foo}"
 
     it "requires a wildcard if there are any rule cases" $ do
-      parse cardinalPluralCases' `shouldFailOn`    "=0 {foo} one {bar}"
-      parse cardinalPluralCases' `shouldSucceedOn` "=0 {foo} one {bar} other {baz}"
-      parse cardinalPluralCases' `shouldSucceedOn` "=0 {foo} =1 {bar}"
+      parse cardinalCases' `shouldFailOn`    "=0 {foo} one {bar}"
+      parse cardinalCases' `shouldSucceedOn` "=0 {foo} one {bar} other {baz}"
+      parse cardinalCases' `shouldSucceedOn` "=0 {foo} =1 {bar}"
 
     it "parses literal and plural cases, wildcard, and interpolation token" $ do
-      parseWith (emptyState { pluralCtxName = Just "xyz" }) cardinalPluralCases' "=0 {foo} few {bar} other {baz #}" `shouldParse`
+      parseWith (emptyState { pluralCtxName = Just "xyz" }) cardinalCases' "=0 {foo} few {bar} other {baz #}" `shouldParse`
         CardinalInexact (pure $ PluralCase (PluralExact "0") [Plaintext "foo"]) (pure $ PluralCase Few [Plaintext "bar"]) (PluralWildcard [Plaintext "baz ", Interpolation "xyz" PluralRef])
 
   describe "selectordinal" $ do

--- a/test/Intlc/Parser/ICUSpec.hs
+++ b/test/Intlc/Parser/ICUSpec.hs
@@ -191,8 +191,8 @@ spec = describe "ICU parser" $ do
       parse ordinalPluralCases `shouldSucceedOn` "=0 {foo} one {bar} other {baz}"
 
     it "parses literal and plural cases, wildcard, and interpolation token" $ do
-      parseWith (emptyState { pluralCtxName = Just "xyz" }) cardinalPluralCases "=0 {foo} few {bar} other {baz #}" `shouldParse`
-        CardinalInexact (pure $ PluralCase (PluralExact "0") [Plaintext "foo"]) (pure $ PluralCase Few [Plaintext "bar"]) (PluralWildcard [Plaintext "baz ", Interpolation "xyz" PluralRef])
+      parseWith (emptyState { pluralCtxName = Just "xyz" }) ordinalPluralCases "=0 {foo} few {bar} other {baz #}" `shouldParse`
+        Ordinal (pure $ PluralCase (PluralExact "0") [Plaintext "foo"]) (pure $ PluralCase Few [Plaintext "bar"]) (PluralWildcard [Plaintext "baz ", Interpolation "xyz" PluralRef])
 
   describe "select" $ do
     let selectCases' = selectCases <* eof

--- a/test/Intlc/Parser/ICUSpec.hs
+++ b/test/Intlc/Parser/ICUSpec.hs
@@ -174,24 +174,24 @@ spec = describe "ICU parser" $ do
         CardinalInexact (pure $ PluralCase (PluralExact "0") [Plaintext "foo"]) (pure $ PluralCase Few [Plaintext "bar"]) (PluralWildcard [Plaintext "baz ", Interpolation "xyz" PluralRef])
 
   describe "selectordinal" $ do
+    let ordinalPluralCases' = ordinalPluralCases <* eof
+
     it "disallows wildcard not at the end" $ do
-      parse ordinalPluralCases `shouldSucceedOn` "one {foo} other {bar}"
-      parse ordinalPluralCases `shouldFailOn` "other {bar} one {foo}"
+      parse ordinalPluralCases' `shouldSucceedOn` "one {foo} other {bar}"
+      parse ordinalPluralCases' `shouldFailOn` "other {bar} one {foo}"
 
     it "tolerates empty cases" $ do
-      parse ordinalPluralCases `shouldSucceedOn` "one {} other {}"
+      parse ordinalPluralCases' `shouldSucceedOn` "one {} other {}"
 
-    it "requires at least one rule" $ do
-      parse ordinalPluralCases `shouldFailOn` "other {foo}"
-      parse ordinalPluralCases `shouldSucceedOn` "one {foo} other {bar}"
-      parse ordinalPluralCases `shouldSucceedOn` "one {foo} two {bar} other {baz}"
+    it "tolerates no non-wildcard cases" $ do
+      parse ordinalPluralCases' `shouldSucceedOn` "other {foo}"
 
     it "requires a wildcard" $ do
-      parse ordinalPluralCases `shouldFailOn`    "=0 {foo} one {bar}"
-      parse ordinalPluralCases `shouldSucceedOn` "=0 {foo} one {bar} other {baz}"
+      parse ordinalPluralCases' `shouldFailOn`    "=0 {foo} one {bar}"
+      parse ordinalPluralCases' `shouldSucceedOn` "=0 {foo} one {bar} other {baz}"
 
     it "parses literal and plural cases, wildcard, and interpolation token" $ do
-      parseWith (emptyState { pluralCtxName = Just "xyz" }) ordinalPluralCases "=0 {foo} few {bar} other {baz #}" `shouldParse`
+      parseWith (emptyState { pluralCtxName = Just "xyz" }) ordinalPluralCases' "=0 {foo} few {bar} other {baz #}" `shouldParse`
         Ordinal (pure $ PluralCase (PluralExact "0") [Plaintext "foo"]) (pure $ PluralCase Few [Plaintext "bar"]) (PluralWildcard [Plaintext "baz ", Interpolation "xyz" PluralRef])
 
   describe "select" $ do

--- a/test/Intlc/Parser/ICUSpec.hs
+++ b/test/Intlc/Parser/ICUSpec.hs
@@ -174,24 +174,24 @@ spec = describe "ICU parser" $ do
         CardinalInexact (pure $ PluralCase (PluralExact "0") [Plaintext "foo"]) (pure $ PluralCase Few [Plaintext "bar"]) (PluralWildcard [Plaintext "baz ", Interpolation "xyz" PluralRef])
 
   describe "selectordinal" $ do
-    let ordinalPluralCases' = ordinalPluralCases <* eof
+    let ordinalCases' = ordinalCases <* eof
 
     it "disallows wildcard not at the end" $ do
-      parse ordinalPluralCases' `shouldSucceedOn` "one {foo} other {bar}"
-      parse ordinalPluralCases' `shouldFailOn` "other {bar} one {foo}"
+      parse ordinalCases' `shouldSucceedOn` "one {foo} other {bar}"
+      parse ordinalCases' `shouldFailOn` "other {bar} one {foo}"
 
     it "tolerates empty cases" $ do
-      parse ordinalPluralCases' `shouldSucceedOn` "one {} other {}"
+      parse ordinalCases' `shouldSucceedOn` "one {} other {}"
 
     it "tolerates no non-wildcard cases" $ do
-      parse ordinalPluralCases' `shouldSucceedOn` "other {foo}"
+      parse ordinalCases' `shouldSucceedOn` "other {foo}"
 
     it "requires a wildcard" $ do
-      parse ordinalPluralCases' `shouldFailOn`    "=0 {foo} one {bar}"
-      parse ordinalPluralCases' `shouldSucceedOn` "=0 {foo} one {bar} other {baz}"
+      parse ordinalCases' `shouldFailOn`    "=0 {foo} one {bar}"
+      parse ordinalCases' `shouldSucceedOn` "=0 {foo} one {bar} other {baz}"
 
     it "parses literal and plural cases, wildcard, and interpolation token" $ do
-      parseWith (emptyState { pluralCtxName = Just "xyz" }) ordinalPluralCases' "=0 {foo} few {bar} other {baz #}" `shouldParse`
+      parseWith (emptyState { pluralCtxName = Just "xyz" }) ordinalCases' "=0 {foo} few {bar} other {baz #}" `shouldParse`
         Ordinal (pure $ PluralCase (PluralExact "0") [Plaintext "foo"]) (pure $ PluralCase Few [Plaintext "bar"]) (PluralWildcard [Plaintext "baz ", Interpolation "xyz" PluralRef])
 
   describe "select" $ do

--- a/test/Intlc/Parser/ICUSpec.hs
+++ b/test/Intlc/Parser/ICUSpec.hs
@@ -152,25 +152,25 @@ spec = describe "ICU parser" $ do
       parse callback `shouldFailOn` "<x y></x y>"
 
   describe "plural" $ do
+    let cardinalPluralCases' = cardinalPluralCases <* eof
+
     it "disallows wildcard not at the end" $ do
-      parse cardinalPluralCases `shouldSucceedOn` "=1 {foo} other {bar}"
-      parse cardinalPluralCases `shouldFailOn` "other {bar} =1 {foo}"
+      parse cardinalPluralCases' `shouldSucceedOn` "=1 {foo} other {bar}"
+      parse cardinalPluralCases' `shouldFailOn` "other {bar} =1 {foo}"
 
     it "tolerates empty cases" $ do
-      parse cardinalPluralCases `shouldSucceedOn` "=1 {} other {}"
+      parse cardinalPluralCases' `shouldSucceedOn` "=1 {} other {}"
 
-    it "requires at least one non-wildcard case" $ do
-      parse cardinalPluralCases `shouldFailOn` "other {foo}"
-      parse cardinalPluralCases `shouldSucceedOn` "=0 {foo} other {bar}"
-      parse cardinalPluralCases `shouldSucceedOn` "one {foo} other {bar}"
+    it "tolerates no non-wildcard cases" $ do
+      parse cardinalPluralCases' `shouldSucceedOn` "other {foo}"
 
     it "requires a wildcard if there are any rule cases" $ do
-      parse cardinalPluralCases `shouldFailOn`    "=0 {foo} one {bar}"
-      parse cardinalPluralCases `shouldSucceedOn` "=0 {foo} one {bar} other {baz}"
-      parse cardinalPluralCases `shouldSucceedOn` "=0 {foo} =1 {bar}"
+      parse cardinalPluralCases' `shouldFailOn`    "=0 {foo} one {bar}"
+      parse cardinalPluralCases' `shouldSucceedOn` "=0 {foo} one {bar} other {baz}"
+      parse cardinalPluralCases' `shouldSucceedOn` "=0 {foo} =1 {bar}"
 
     it "parses literal and plural cases, wildcard, and interpolation token" $ do
-      parseWith (emptyState { pluralCtxName = Just "xyz" }) cardinalPluralCases "=0 {foo} few {bar} other {baz #}" `shouldParse`
+      parseWith (emptyState { pluralCtxName = Just "xyz" }) cardinalPluralCases' "=0 {foo} few {bar} other {baz #}" `shouldParse`
         CardinalInexact (pure $ PluralCase (PluralExact "0") [Plaintext "foo"]) (pure $ PluralCase Few [Plaintext "bar"]) (PluralWildcard [Plaintext "baz ", Interpolation "xyz" PluralRef])
 
   describe "selectordinal" $ do


### PR DESCRIPTION
Closes #108. #136 will follow in another PR.

Given:

```json
{
  "f": { "message": "{n, plural, other {}}" },
  "g": { "message": "{n, selectordinal, other {}}" },
}
```

Previously:

```console
$ intlc compile -l foo ./bar.json
./bar.json:2:34:
  |
2 |   "f": { "message": "{n, plural, other {}}" },
  |                                  ^^^^
unexpected "othe"
expecting "few", "many", "one", "two", "zero", '=', or white space

./bar.json:3:41:
  |
3 |   "g": { "message": "{n, selectordinal, other {}}" },
  |                                         ^^^^
unexpected "othe"
expecting "few", "many", "one", "two", "zero", '=', or white space
```

Now:

```console
$ intlc compile -l foo ./bar.json
export const f: (x: { n: number }) => string = x => `${(() => { switch (x.n as typeof x.n) {  default: return ``; } })()}`
export const g: (x: { n: number }) => string = x => `${(() => { switch (new Intl.PluralRules('xyz', { type: 'ordinal' }).select(x.n)) {  default: return ``; } })()}`
```

Most of the diff is due to changes to the shape of the AST. Most attention should be paid to those AST changes themselves, and then the drastically simplified parsing (:smiley:). The tests should have caught any potential regressions... in theory!

Looking at the output there's a lot of space for optimisation, but I'm avoiding anything like that for now in pursuit of a simple compiler, as with how we solved #111.