### PR TITLE
Add HLS to dev shell

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     flake-utils.lib.eachDefaultSystem (system:
       let pkgs = nixpkgs.legacyPackages.${system};
       in {
-        devShell = pkgs.mkShell {
+        devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [
             git
 

--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,7 @@
 
             haskell.compiler.ghc8107
             haskell.packages.ghc8107.cabal-install
+            haskell.packages.ghc8107.haskell-language-server
             haskell.packages.ghc8107.hspec-golden
 
             # For typechecking golden output


### PR DESCRIPTION
Installing it per-project is preferred as HLS is bound quite tightly to specific versions of GHC.

I had a binary available for download from CI with this. Is that also the case on macOS? I wouldn't want to merge this if it needs to be built from source.