### PR TITLE
Flat AST

### DIFF
--- a/intlc.cabal
+++ b/intlc.cabal
@@ -13,6 +13,7 @@ common common
     -- These are included in GHC2021.
     DeriveGeneric
     FlexibleContexts
+    GeneralizedNewtypeDeriving
     NamedFieldPuns
     TupleSections
   ghc-options:

--- a/intlc.cabal
+++ b/intlc.cabal
@@ -27,7 +27,6 @@ common common
     , optics               ^>=0.4
     , relude               ^>=1.1
     , text                 ^>=1.2
-    , these                ^>=1.1
     , validation           ^>=1.1
   mixins:
       base hiding (Prelude)

--- a/lib/Intlc/Backend/ICU/Compiler.hs
+++ b/lib/Intlc/Backend/ICU/Compiler.hs
@@ -19,23 +19,20 @@ stream :: Foldable f => f Token -> Text
 stream = foldMap token
 
 token :: Token -> Text
-token (Plaintext x)       = x
-token (Interpolation x y) = interp x y
-
-interp :: Text -> Type -> Text
-interp n Bool { trueCase, falseCase } = "{" <> n <> ", boolean, true {" <> stream trueCase  <> "} false {" <> stream falseCase <> "}}"
-interp n String                       = "{" <> n <> "}"
-interp n Number                       = "{" <> n <> ", number}"
-interp n (Date fmt)                   = "{" <> n <> ", date, "          <> dateTimeFmt fmt  <> "}"
-interp n (Time fmt)                   = "{" <> n <> ", time, "          <> dateTimeFmt fmt  <> "}"
-interp n (Plural p)                   = "{" <> n <> ", " <> typ <> ", " <> plural p         <> "}"
+token (Plaintext x)   = x
+token x@(Bool {})     = "{" <> name x <> ", boolean, true {" <> stream (trueCase x)  <> "} false {" <> stream (falseCase x) <> "}}"
+token (String n)      = "{" <> n <> "}"
+token (Number n)      = "{" <> n <> ", number}"
+token (Date n fmt)    = "{" <> n <> ", date, "          <> dateTimeFmt fmt  <> "}"
+token (Time n fmt)    = "{" <> n <> ", time, "          <> dateTimeFmt fmt  <> "}"
+token (Plural n p)    = "{" <> n <> ", " <> typ <> ", " <> plural p         <> "}"
   where typ = case p of
           CardinalExact {}   -> "plural"
           CardinalInexact {} -> "plural"
           Ordinal {}         -> "selectordinal"
-interp _ PluralRef                    = "#"
-interp n (Select x)                   = "{" <> n <> ", select, "        <> select x         <> "}"
-interp n (Callback xs)                = "<" <> n <> ">"                 <> stream xs        <> "</" <> n <> ">"
+token PluralRef {}    = "#"
+token (Select n x)    = "{" <> n <> ", select, "        <> select x         <> "}"
+token (Callback n xs) = "<" <> n <> ">"                 <> stream xs        <> "</" <> n <> ">"
 
 dateTimeFmt :: DateTimeFmt -> Text
 dateTimeFmt Short  = "short"

--- a/lib/Intlc/Backend/ICU/Compiler.hs
+++ b/lib/Intlc/Backend/ICU/Compiler.hs
@@ -59,5 +59,5 @@ pluralWildcard xs = "other {" <> stream xs <> "}"
 
 select :: These (NonEmpty SelectCase) SelectWildcard -> Text
 select = unwords . bifoldMap (toList . fmap case') (pure . wild)
-  where case' (SelectCase n ys) = n <> " {" <> stream ys <> "}"
+  where case' (n, ys) = n <> " {" <> stream ys <> "}"
         wild (SelectWildcard ys) = "other {" <> stream ys <> "}"

--- a/lib/Intlc/Backend/ICU/Compiler.hs
+++ b/lib/Intlc/Backend/ICU/Compiler.hs
@@ -15,24 +15,24 @@ import           Prelude    hiding (Type)
 compileMsg :: Message -> Text
 compileMsg (Message xs) = stream xs
 
-stream :: Foldable f => f Token -> Text
-stream = foldMap token
+stream :: Foldable f => f Node -> Text
+stream = foldMap node
 
-token :: Token -> Text
-token (Plaintext x)   = x
-token x@(Bool {})     = "{" <> (unArg . name $ x) <> ", boolean, true {" <> stream (trueCase x)  <> "} false {" <> stream (falseCase x) <> "}}"
-token (String n)      = "{" <> unArg n <> "}"
-token (Number n)      = "{" <> unArg n <> ", number}"
-token (Date n fmt)    = "{" <> unArg n <> ", date, "          <> dateTimeFmt fmt  <> "}"
-token (Time n fmt)    = "{" <> unArg n <> ", time, "          <> dateTimeFmt fmt  <> "}"
-token (Plural n p)    = "{" <> unArg n <> ", " <> typ <> ", " <> plural p         <> "}"
+node :: Node -> Text
+node (Plaintext x)   = x
+node x@(Bool {})     = "{" <> (unArg . name $ x) <> ", boolean, true {" <> stream (trueCase x)  <> "} false {" <> stream (falseCase x) <> "}}"
+node (String n)      = "{" <> unArg n <> "}"
+node (Number n)      = "{" <> unArg n <> ", number}"
+node (Date n fmt)    = "{" <> unArg n <> ", date, "          <> dateTimeFmt fmt  <> "}"
+node (Time n fmt)    = "{" <> unArg n <> ", time, "          <> dateTimeFmt fmt  <> "}"
+node (Plural n p)    = "{" <> unArg n <> ", " <> typ <> ", " <> plural p         <> "}"
   where typ = case p of
           CardinalExact {}   -> "plural"
           CardinalInexact {} -> "plural"
           Ordinal {}         -> "selectordinal"
-token PluralRef {}    = "#"
-token (Select n x)    = "{" <> unArg n <> ", select, "        <> select x         <> "}"
-token (Callback n xs) = "<" <> unArg n <> ">"                 <> stream xs        <> "</" <> unArg n <> ">"
+node PluralRef {}    = "#"
+node (Select n x)    = "{" <> unArg n <> ", select, "        <> select x         <> "}"
+node (Callback n xs) = "<" <> unArg n <> ">"                 <> stream xs        <> "</" <> unArg n <> ">"
 
 dateTimeFmt :: DateTimeFmt -> Text
 dateTimeFmt Short  = "short"

--- a/lib/Intlc/Backend/ICU/Compiler.hs
+++ b/lib/Intlc/Backend/ICU/Compiler.hs
@@ -57,7 +57,7 @@ pluralRule Many = "many"
 pluralWildcard :: Stream -> Text
 pluralWildcard xs = "other {" <> stream xs <> "}"
 
-select :: These (NonEmpty SelectCase) SelectWildcard -> Text
+select :: These (NonEmpty SelectCase) Stream -> Text
 select = unwords . bifoldMap (toList . fmap case') (pure . wild)
   where case' (n, ys) = n <> " {" <> stream ys <> "}"
-        wild (SelectWildcard ys) = "other {" <> stream ys <> "}"
+        wild ys = "other {" <> stream ys <> "}"

--- a/lib/Intlc/Backend/ICU/Compiler.hs
+++ b/lib/Intlc/Backend/ICU/Compiler.hs
@@ -9,7 +9,7 @@
 module Intlc.Backend.ICU.Compiler where
 
 import           Intlc.ICU
-import           Prelude    hiding (Type)
+import           Prelude   hiding (Type)
 
 compileMsg :: Message -> Text
 compileMsg (Message xs) = stream xs

--- a/lib/Intlc/Backend/ICU/Compiler.hs
+++ b/lib/Intlc/Backend/ICU/Compiler.hs
@@ -54,8 +54,8 @@ pluralRule Two  = "two"
 pluralRule Few  = "few"
 pluralRule Many = "many"
 
-pluralWildcard :: PluralWildcard -> Text
-pluralWildcard (PluralWildcard xs) = "other {" <> stream xs <> "}"
+pluralWildcard :: Stream -> Text
+pluralWildcard xs = "other {" <> stream xs <> "}"
 
 select :: These (NonEmpty SelectCase) SelectWildcard -> Text
 select = unwords . bifoldMap (toList . fmap case') (pure . wild)

--- a/lib/Intlc/Backend/ICU/Compiler.hs
+++ b/lib/Intlc/Backend/ICU/Compiler.hs
@@ -42,10 +42,10 @@ dateTimeFmt Long   = "long"
 dateTimeFmt Full   = "full"
 
 exactPluralCase :: PluralCase PluralExact -> Text
-exactPluralCase (PluralCase (PluralExact n) xs) = "=" <> n <> " {" <> stream xs <> "}"
+exactPluralCase (PluralExact n, xs) = "=" <> n <> " {" <> stream xs <> "}"
 
 rulePluralCase :: PluralCase PluralRule -> Text
-rulePluralCase (PluralCase r xs) = pluralRule r <> " {" <> stream xs <> "}"
+rulePluralCase (r, xs) = pluralRule r <> " {" <> stream xs <> "}"
 
 pluralRule :: PluralRule -> Text
 pluralRule Zero = "zero"

--- a/lib/Intlc/Backend/ICU/Compiler.hs
+++ b/lib/Intlc/Backend/ICU/Compiler.hs
@@ -20,19 +20,19 @@ stream = foldMap token
 
 token :: Token -> Text
 token (Plaintext x)   = x
-token x@(Bool {})     = "{" <> name x <> ", boolean, true {" <> stream (trueCase x)  <> "} false {" <> stream (falseCase x) <> "}}"
-token (String n)      = "{" <> n <> "}"
-token (Number n)      = "{" <> n <> ", number}"
-token (Date n fmt)    = "{" <> n <> ", date, "          <> dateTimeFmt fmt  <> "}"
-token (Time n fmt)    = "{" <> n <> ", time, "          <> dateTimeFmt fmt  <> "}"
-token (Plural n p)    = "{" <> n <> ", " <> typ <> ", " <> plural p         <> "}"
+token x@(Bool {})     = "{" <> (unArg . name $ x) <> ", boolean, true {" <> stream (trueCase x)  <> "} false {" <> stream (falseCase x) <> "}}"
+token (String n)      = "{" <> unArg n <> "}"
+token (Number n)      = "{" <> unArg n <> ", number}"
+token (Date n fmt)    = "{" <> unArg n <> ", date, "          <> dateTimeFmt fmt  <> "}"
+token (Time n fmt)    = "{" <> unArg n <> ", time, "          <> dateTimeFmt fmt  <> "}"
+token (Plural n p)    = "{" <> unArg n <> ", " <> typ <> ", " <> plural p         <> "}"
   where typ = case p of
           CardinalExact {}   -> "plural"
           CardinalInexact {} -> "plural"
           Ordinal {}         -> "selectordinal"
 token PluralRef {}    = "#"
-token (Select n x)    = "{" <> n <> ", select, "        <> select x         <> "}"
-token (Callback n xs) = "<" <> n <> ">"                 <> stream xs        <> "</" <> n <> ">"
+token (Select n x)    = "{" <> unArg n <> ", select, "        <> select x         <> "}"
+token (Callback n xs) = "<" <> unArg n <> ">"                 <> stream xs        <> "</" <> unArg n <> ">"
 
 dateTimeFmt :: DateTimeFmt -> Text
 dateTimeFmt Short  = "short"

--- a/lib/Intlc/Backend/ICU/Compiler.hs
+++ b/lib/Intlc/Backend/ICU/Compiler.hs
@@ -25,11 +25,12 @@ node (String n)      = "{" <> unArg n <> "}"
 node (Number n)      = "{" <> unArg n <> ", number}"
 node (Date n fmt)    = "{" <> unArg n <> ", date, "          <> dateTimeFmt fmt  <> "}"
 node (Time n fmt)    = "{" <> unArg n <> ", time, "          <> dateTimeFmt fmt  <> "}"
-node (Plural n p)    = "{" <> unArg n <> ", " <> typ <> ", " <> plural p         <> "}"
-  where typ = case p of
-          CardinalExact {}   -> "plural"
-          CardinalInexact {} -> "plural"
-          Ordinal {}         -> "selectordinal"
+node (CardinalExact n xs)        = "{" <> unArg n <> ", plural, " <> cases <> "}"
+  where cases = unwords . toList . fmap exactPluralCase $ xs
+node (CardinalInexact n xs ys w) = "{" <> unArg n <> ", plural, " <> cases <> "}"
+  where cases = unwords . mconcat $ [exactPluralCase <$> xs, rulePluralCase <$> ys, pure $ pluralWildcard w]
+node (Ordinal n xs ys w)         = "{" <> unArg n <> ", selectordinal, " <> cases <> "}"
+  where cases = unwords $ (exactPluralCase <$> xs) <> (rulePluralCase <$> ys) <> pure (pluralWildcard w)
 node PluralRef {}    = "#"
 node (Select n x)    = "{" <> unArg n <> ", select, "        <> select x         <> "}"
 node (Callback n xs) = "<" <> unArg n <> ">"                 <> stream xs        <> "</" <> unArg n <> ">"
@@ -39,12 +40,6 @@ dateTimeFmt Short  = "short"
 dateTimeFmt Medium = "medium"
 dateTimeFmt Long   = "long"
 dateTimeFmt Full   = "full"
-
-plural :: Plural -> Text
-plural (CardinalExact xs)        = unwords . toList . fmap exactPluralCase $ xs
-plural (CardinalInexact xs ys w) = unwords . mconcat $ [exactPluralCase <$> xs, rulePluralCase <$> ys, pure $ pluralWildcard w]
-plural (Ordinal xs ys w)         = unwords $
-  (exactPluralCase <$> xs) <> (rulePluralCase <$> ys) <> pure (pluralWildcard w)
 
 exactPluralCase :: PluralCase PluralExact -> Text
 exactPluralCase (PluralCase (PluralExact n) xs) = "=" <> n <> " {" <> stream xs <> "}"

--- a/lib/Intlc/Backend/JavaScript/Compiler.hs
+++ b/lib/Intlc/Backend/JavaScript/Compiler.hs
@@ -70,8 +70,8 @@ fromStrat JSX         = Interp
 argName :: Text
 argName = "x"
 
-prop :: Ref -> Text
-prop (Ref x) = argName <> "." <> x
+prop :: ICU.Arg -> Text
+prop (ICU.Arg x) = argName <> "." <> x
 
 wrap :: Text -> Compiler Text
 wrap x = do
@@ -106,7 +106,7 @@ expr (TTime x fmt) = interpc =<< time x fmt
 expr (TApply x ys) = interpc =<< apply x ys
 expr (TMatch x)    = interpc =<< match x
 
-apply :: Ref -> [Expr] -> Compiler Text
+apply :: ICU.Arg -> [Expr] -> Compiler Text
 apply x ys = pure (prop x <> "(") <>^ (wrap =<< exprs ys) <>^ pure ")"
 
 match :: Match -> Compiler Text
@@ -126,19 +126,19 @@ match = fmap iife . go where
   recBranches xs y = (<>) <$> branches xs <*> ((" " <>) . nest <$> y)
     where nest x = "default: { " <> x <> " }"
 
-matchCond :: Ref -> MatchCond -> Compiler Text
+matchCond :: ICU.Arg -> MatchCond -> Compiler Text
 matchCond n LitCond                = override matchLitCondOverride (prop n)
 matchCond n CardinalPluralRuleCond = f <$> asks locale
   where f (Locale l) = "new Intl.PluralRules('" <> l <> "').select(" <> prop n <> ")"
 matchCond n OrdinalPluralRuleCond  = f <$> asks locale
   where f (Locale l) = "new Intl.PluralRules('" <> l <> "', { type: 'ordinal' }).select(" <> prop n <> ")"
 
-date :: Ref -> ICU.DateTimeFmt -> Compiler Text
+date :: ICU.Arg -> ICU.DateTimeFmt -> Compiler Text
 date n d = do
   (Locale l) <- asks locale
   pure $ "new Intl.DateTimeFormat('" <> l <> "', { dateStyle: '" <> dateTimeFmt d <> "' }).format(" <> prop n <> ")"
 
-time :: Ref -> ICU.DateTimeFmt -> Compiler Text
+time :: ICU.Arg -> ICU.DateTimeFmt -> Compiler Text
 time n d = do
   (Locale l) <- asks locale
   pure $ "new Intl.DateTimeFormat('" <> l <> "', { timeStyle: '" <> dateTimeFmt d <> "' }).format(" <> prop n <> ")"

--- a/lib/Intlc/Backend/JavaScript/Language.hs
+++ b/lib/Intlc/Backend/JavaScript/Language.hs
@@ -95,8 +95,8 @@ fromRulePluralCase (r, xs) = Branch (qts matcher) <$> (fromNode `mapM` xs)
          ICU.Many -> "many"
         qts x = "'" <> x <> "'"
 
-fromPluralWildcard :: ICU.PluralWildcard -> ASTCompiler Wildcard
-fromPluralWildcard (ICU.PluralWildcard xs) = Wildcard <$> (fromNode `mapM` xs)
+fromPluralWildcard :: ICU.Stream -> ASTCompiler Wildcard
+fromPluralWildcard xs = Wildcard <$> (fromNode `mapM` xs)
 
 fromSelectCase :: ICU.SelectCase -> ASTCompiler Branch
 fromSelectCase (ICU.SelectCase x ys) = Branch ("'" <> x <> "'") <$> (fromNode `mapM` ys)

--- a/lib/Intlc/Backend/JavaScript/Language.hs
+++ b/lib/Intlc/Backend/JavaScript/Language.hs
@@ -1,6 +1,5 @@
 module Intlc.Backend.JavaScript.Language where
 
-import           Data.These (These (..))
 import           Intlc.Core (Locale)
 import qualified Intlc.ICU  as ICU
 import           Prelude
@@ -73,13 +72,12 @@ fromNode (ICU.Ordinal n (lc:lcs) rcs w)         = TMatch . Match n LitCond <$> m
           im = Match n OrdinalPluralRuleCond <$> (NonLitMatchRet <$> (fromRulePluralCase `mapM` rcs) <*> fromPluralWildcard w)
 
 fromNode (ICU.PluralRef n)   = pure $ TNum n
-fromNode (ICU.Select n x)    = case x of
-      (This cs)    -> TMatch . Match n LitCond . LitMatchRet <$> ret
-        where ret = fromSelectCase `mapM` cs
-      (That w)     -> TMatch . Match n LitCond <$> ret
-        where ret = NonLitMatchRet mempty <$> fromSelectWildcard w
-      (These cs w) -> TMatch . Match n LitCond <$> ret
-        where ret = NonLitMatchRet <$> (toList <$> fromSelectCase `mapM` cs) <*> fromSelectWildcard w
+fromNode (ICU.SelectNamed n cs)       = TMatch . Match n LitCond . LitMatchRet <$> ret
+  where ret = fromSelectCase `mapM` cs
+fromNode (ICU.SelectWild n w)         = TMatch . Match n LitCond <$> ret
+  where ret = NonLitMatchRet mempty <$> fromSelectWildcard w
+fromNode (ICU.SelectNamedWild n cs w) = TMatch . Match n LitCond <$> ret
+  where ret = NonLitMatchRet <$> (toList <$> fromSelectCase `mapM` cs) <*> fromSelectWildcard w
 fromNode (ICU.Callback n xs) = TApply n <$> (fromNode `mapM` xs)
 
 fromExactPluralCase :: ICU.PluralCase ICU.PluralExact -> ASTCompiler Branch

--- a/lib/Intlc/Backend/JavaScript/Language.hs
+++ b/lib/Intlc/Backend/JavaScript/Language.hs
@@ -101,8 +101,8 @@ fromPluralWildcard xs = Wildcard <$> (fromNode `mapM` xs)
 fromSelectCase :: ICU.SelectCase -> ASTCompiler Branch
 fromSelectCase (x, ys) = Branch ("'" <> x <> "'") <$> (fromNode `mapM` ys)
 
-fromSelectWildcard :: ICU.SelectWildcard -> ASTCompiler Wildcard
-fromSelectWildcard (ICU.SelectWildcard xs) = Wildcard <$> (fromNode `mapM` xs)
+fromSelectWildcard :: ICU.Stream -> ASTCompiler Wildcard
+fromSelectWildcard xs = Wildcard <$> (fromNode `mapM` xs)
 
 fromBoolCase :: Bool -> ICU.Stream -> ASTCompiler Branch
 fromBoolCase b xs = Branch b' <$> (fromNode `mapM` xs)

--- a/lib/Intlc/Backend/JavaScript/Language.hs
+++ b/lib/Intlc/Backend/JavaScript/Language.hs
@@ -99,7 +99,7 @@ fromPluralWildcard :: ICU.Stream -> ASTCompiler Wildcard
 fromPluralWildcard xs = Wildcard <$> (fromNode `mapM` xs)
 
 fromSelectCase :: ICU.SelectCase -> ASTCompiler Branch
-fromSelectCase (ICU.SelectCase x ys) = Branch ("'" <> x <> "'") <$> (fromNode `mapM` ys)
+fromSelectCase (x, ys) = Branch ("'" <> x <> "'") <$> (fromNode `mapM` ys)
 
 fromSelectWildcard :: ICU.SelectWildcard -> ASTCompiler Wildcard
 fromSelectWildcard (ICU.SelectWildcard xs) = Wildcard <$> (fromNode `mapM` xs)

--- a/lib/Intlc/Backend/JavaScript/Language.hs
+++ b/lib/Intlc/Backend/JavaScript/Language.hs
@@ -83,10 +83,10 @@ fromNode (ICU.Select n x)    = case x of
 fromNode (ICU.Callback n xs) = TApply n <$> (fromNode `mapM` xs)
 
 fromExactPluralCase :: ICU.PluralCase ICU.PluralExact -> ASTCompiler Branch
-fromExactPluralCase (ICU.PluralCase (ICU.PluralExact n) xs) = Branch n <$> (fromNode `mapM` xs)
+fromExactPluralCase (ICU.PluralExact n, xs) = Branch n <$> (fromNode `mapM` xs)
 
 fromRulePluralCase :: ICU.PluralCase ICU.PluralRule -> ASTCompiler Branch
-fromRulePluralCase (ICU.PluralCase r xs) = Branch (qts matcher) <$> (fromNode `mapM` xs)
+fromRulePluralCase (r, xs) = Branch (qts matcher) <$> (fromNode `mapM` xs)
   where matcher = case r of
          ICU.Zero -> "zero"
          ICU.One  -> "one"

--- a/lib/Intlc/Backend/TypeScript/Compiler.hs
+++ b/lib/Intlc/Backend/TypeScript/Compiler.hs
@@ -23,8 +23,8 @@ compileNamedExport s l k v = JS.compileStmt o s l k v
         matchLitCond x = x <> " as typeof " <> x
         arg = if hasInterpolations then "x" else "()"
         hasInterpolations = flip any (ICU.unMessage v) $ \case
-          ICU.Interpolation {} -> True
-          ICU.Plaintext {}     -> False
+          ICU.Plaintext {} -> False
+          _                -> True
 
 compileTypeof :: InterpStrat -> ICU.Message -> Text
 compileTypeof x = let o = fromStrat x in flip runReader o . typeof . fromMsg o

--- a/lib/Intlc/Backend/TypeScript/Compiler.hs
+++ b/lib/Intlc/Backend/TypeScript/Compiler.hs
@@ -54,8 +54,8 @@ args xs
   | otherwise = do
     y <- fmap (T.intercalate "; " . M.elems) . M.traverseWithKey arg $ xs
     pure $ "(" <> argName <> ": { " <> y <> " })"
-      where arg k (v :| []) = ((k <> ": ") <>) <$> in' v
-            arg k vs        = ((k <> ": ") <>) . intersect . toList <$> ins `mapM` vs
+      where arg (ICU.Arg k) (v :| []) = ((k <> ": ") <>) <$> in' v
+            arg (ICU.Arg k) vs        = ((k <> ": ") <>) . intersect . toList <$> ins `mapM` vs
             -- Unions with at least two members need wrapping in disambiguating
             -- parentheses, other types do not.
             ins x

--- a/lib/Intlc/Backend/TypeScript/Language.hs
+++ b/lib/Intlc/Backend/TypeScript/Language.hs
@@ -64,8 +64,7 @@ fromNode (ICU.Select n x)    = case x of
   (That w)     -> (n, TStr) : fromSelectWildcard w
   (These cs w) -> (n, TStr) : (fromSelectCase =<< toList cs) <> fromSelectWildcard w
   -- When there's no wildcard case we can compile to a union of string literals.
-  (This cs)    -> (n, TStrLitUnion (lit <$> cs)) : (fromSelectCase =<< toList cs)
-    where lit (ICU.SelectCase l _) = l
+  (This cs)    -> (n, TStrLitUnion (fst <$> cs)) : (fromSelectCase =<< toList cs)
 fromNode (ICU.Callback n xs) = (n, TEndo) : (fromNode =<< xs)
 
 fromExactPluralCase :: ICU.PluralCase ICU.PluralExact -> UncollatedArgs
@@ -75,7 +74,7 @@ fromRulePluralCase :: ICU.PluralCase ICU.PluralRule -> UncollatedArgs
 fromRulePluralCase (_, xs) = fromNode =<< xs
 
 fromSelectCase :: ICU.SelectCase -> UncollatedArgs
-fromSelectCase (ICU.SelectCase _ xs) = fromNode =<< xs
+fromSelectCase (_, xs) = fromNode =<< xs
 
 fromSelectWildcard :: ICU.SelectWildcard -> UncollatedArgs
 fromSelectWildcard (ICU.SelectWildcard xs) = fromNode =<< xs

--- a/lib/Intlc/Backend/TypeScript/Language.hs
+++ b/lib/Intlc/Backend/TypeScript/Language.hs
@@ -12,8 +12,8 @@ import           Prelude
 data TypeOf = Lambda Args Out
   deriving (Show, Eq)
 
-type UncollatedArgs = [(Text, In)]
-type Args = Map Text (NonEmpty In)
+type UncollatedArgs = [(ICU.Arg, In)]
+type Args = Map ICU.Arg (NonEmpty In)
 
 data In
   = TStr
@@ -62,7 +62,7 @@ fromToken (ICU.Select n x)    = case x of
     where lit (ICU.SelectCase l _) = l
 fromToken (ICU.Callback n xs) = (n, TEndo) : (fromToken =<< xs)
 
-fromPlural :: Text -> ICU.Plural -> UncollatedArgs
+fromPlural :: ICU.Arg -> ICU.Plural -> UncollatedArgs
 -- We can compile exact cardinal plurals (i.e. those without a wildcard) to a
 -- union of number literals.
 fromPlural n (ICU.CardinalExact ls)        = (n, t) : (fromExactPluralCase =<< toList ls)

--- a/lib/Intlc/Backend/TypeScript/Language.hs
+++ b/lib/Intlc/Backend/TypeScript/Language.hs
@@ -55,7 +55,7 @@ fromNode (ICU.Time n _)      = pure (n, TDate)
 -- union of number literals.
 fromNode (ICU.CardinalExact n ls)        = (n, t) : (fromExactPluralCase =<< toList ls)
   where t = TNumLitUnion $ caseLit <$> ls
-        caseLit (ICU.PluralCase (ICU.PluralExact x) _) = x
+        caseLit (ICU.PluralExact x, _) = x
 fromNode (ICU.CardinalInexact n ls rs w) = (n, TNum) : (fromExactPluralCase =<< ls) <> (fromRulePluralCase =<< rs) <> fromPluralWildcard w
 fromNode (ICU.Ordinal n ls rs w)         = (n, TNum) : (fromExactPluralCase =<< ls) <> (fromRulePluralCase =<< rs) <> fromPluralWildcard w
 -- Plural references are treated as a no-op.
@@ -69,10 +69,10 @@ fromNode (ICU.Select n x)    = case x of
 fromNode (ICU.Callback n xs) = (n, TEndo) : (fromNode =<< xs)
 
 fromExactPluralCase :: ICU.PluralCase ICU.PluralExact -> UncollatedArgs
-fromExactPluralCase (ICU.PluralCase (ICU.PluralExact _) xs) = fromNode =<< xs
+fromExactPluralCase (ICU.PluralExact _, xs) = fromNode =<< xs
 
 fromRulePluralCase :: ICU.PluralCase ICU.PluralRule -> UncollatedArgs
-fromRulePluralCase (ICU.PluralCase _ xs) = fromNode =<< xs
+fromRulePluralCase (_, xs) = fromNode =<< xs
 
 fromPluralWildcard :: ICU.PluralWildcard -> UncollatedArgs
 fromPluralWildcard (ICU.PluralWildcard xs) = fromNode =<< xs

--- a/lib/Intlc/Backend/TypeScript/Language.hs
+++ b/lib/Intlc/Backend/TypeScript/Language.hs
@@ -42,25 +42,25 @@ collateArgs :: UncollatedArgs -> Args
 collateArgs = fmap nub . M.fromListWith (<>) . fmap (second pure)
 
 fromMsg :: Out -> ICU.Message -> TypeOf
-fromMsg x (ICU.Message ys) = Lambda (collateArgs (fromToken =<< toList ys)) x
+fromMsg x (ICU.Message ys) = Lambda (collateArgs (fromNode =<< toList ys)) x
 
-fromToken :: ICU.Token -> UncollatedArgs
-fromToken ICU.Plaintext {}    = mempty
-fromToken (ICU.Bool n xs ys)  = (n, TBool) : (fromToken =<< xs) <> (fromToken =<< ys)
-fromToken (ICU.String n)      = pure (n, TStr)
-fromToken (ICU.Number n)      = pure (n, TNum)
-fromToken (ICU.Date n _)      = pure (n, TDate)
-fromToken (ICU.Time n _)      = pure (n, TDate)
-fromToken (ICU.Plural n x)    = fromPlural n x
+fromNode :: ICU.Node -> UncollatedArgs
+fromNode ICU.Plaintext {}    = mempty
+fromNode (ICU.Bool n xs ys)  = (n, TBool) : (fromNode =<< xs) <> (fromNode =<< ys)
+fromNode (ICU.String n)      = pure (n, TStr)
+fromNode (ICU.Number n)      = pure (n, TNum)
+fromNode (ICU.Date n _)      = pure (n, TDate)
+fromNode (ICU.Time n _)      = pure (n, TDate)
+fromNode (ICU.Plural n x)    = fromPlural n x
 -- Plural references are treated as a no-op.
-fromToken ICU.PluralRef {}    = mempty
-fromToken (ICU.Select n x)    = case x of
+fromNode ICU.PluralRef {}    = mempty
+fromNode (ICU.Select n x)    = case x of
   (That w)     -> (n, TStr) : fromSelectWildcard w
   (These cs w) -> (n, TStr) : (fromSelectCase =<< toList cs) <> fromSelectWildcard w
   -- When there's no wildcard case we can compile to a union of string literals.
   (This cs)    -> (n, TStrLitUnion (lit <$> cs)) : (fromSelectCase =<< toList cs)
     where lit (ICU.SelectCase l _) = l
-fromToken (ICU.Callback n xs) = (n, TEndo) : (fromToken =<< xs)
+fromNode (ICU.Callback n xs) = (n, TEndo) : (fromNode =<< xs)
 
 fromPlural :: ICU.Arg -> ICU.Plural -> UncollatedArgs
 -- We can compile exact cardinal plurals (i.e. those without a wildcard) to a
@@ -72,16 +72,16 @@ fromPlural n (ICU.CardinalInexact ls rs w) = (n, TNum) : (fromExactPluralCase =<
 fromPlural n (ICU.Ordinal ls rs w)         = (n, TNum) : (fromExactPluralCase =<< ls) <> (fromRulePluralCase =<< rs) <> fromPluralWildcard w
 
 fromExactPluralCase :: ICU.PluralCase ICU.PluralExact -> UncollatedArgs
-fromExactPluralCase (ICU.PluralCase (ICU.PluralExact _) xs) = fromToken =<< xs
+fromExactPluralCase (ICU.PluralCase (ICU.PluralExact _) xs) = fromNode =<< xs
 
 fromRulePluralCase :: ICU.PluralCase ICU.PluralRule -> UncollatedArgs
-fromRulePluralCase (ICU.PluralCase _ xs) = fromToken =<< xs
+fromRulePluralCase (ICU.PluralCase _ xs) = fromNode =<< xs
 
 fromPluralWildcard :: ICU.PluralWildcard -> UncollatedArgs
-fromPluralWildcard (ICU.PluralWildcard xs) = fromToken =<< xs
+fromPluralWildcard (ICU.PluralWildcard xs) = fromNode =<< xs
 
 fromSelectCase :: ICU.SelectCase -> UncollatedArgs
-fromSelectCase (ICU.SelectCase _ xs) = fromToken =<< xs
+fromSelectCase (ICU.SelectCase _ xs) = fromNode =<< xs
 
 fromSelectWildcard :: ICU.SelectWildcard -> UncollatedArgs
-fromSelectWildcard (ICU.SelectWildcard xs) = fromToken =<< xs
+fromSelectWildcard (ICU.SelectWildcard xs) = fromNode =<< xs

--- a/lib/Intlc/Backend/TypeScript/Language.hs
+++ b/lib/Intlc/Backend/TypeScript/Language.hs
@@ -56,8 +56,8 @@ fromNode (ICU.Time n _)      = pure (n, TDate)
 fromNode (ICU.CardinalExact n ls)        = (n, t) : (fromExactPluralCase =<< toList ls)
   where t = TNumLitUnion $ caseLit <$> ls
         caseLit (ICU.PluralExact x, _) = x
-fromNode (ICU.CardinalInexact n ls rs w) = (n, TNum) : (fromExactPluralCase =<< ls) <> (fromRulePluralCase =<< rs) <> fromPluralWildcard w
-fromNode (ICU.Ordinal n ls rs w)         = (n, TNum) : (fromExactPluralCase =<< ls) <> (fromRulePluralCase =<< rs) <> fromPluralWildcard w
+fromNode (ICU.CardinalInexact n ls rs w) = (n, TNum) : (fromExactPluralCase =<< ls) <> (fromRulePluralCase =<< rs) <> (fromNode =<< w)
+fromNode (ICU.Ordinal n ls rs w)         = (n, TNum) : (fromExactPluralCase =<< ls) <> (fromRulePluralCase =<< rs) <> (fromNode =<< w)
 -- Plural references are treated as a no-op.
 fromNode ICU.PluralRef {}    = mempty
 fromNode (ICU.Select n x)    = case x of
@@ -73,9 +73,6 @@ fromExactPluralCase (ICU.PluralExact _, xs) = fromNode =<< xs
 
 fromRulePluralCase :: ICU.PluralCase ICU.PluralRule -> UncollatedArgs
 fromRulePluralCase (_, xs) = fromNode =<< xs
-
-fromPluralWildcard :: ICU.PluralWildcard -> UncollatedArgs
-fromPluralWildcard (ICU.PluralWildcard xs) = fromNode =<< xs
 
 fromSelectCase :: ICU.SelectCase -> UncollatedArgs
 fromSelectCase (ICU.SelectCase _ xs) = fromNode =<< xs

--- a/lib/Intlc/Backend/TypeScript/Language.hs
+++ b/lib/Intlc/Backend/TypeScript/Language.hs
@@ -61,8 +61,8 @@ fromNode (ICU.Ordinal n ls rs w)         = (n, TNum) : (fromExactPluralCase =<< 
 -- Plural references are treated as a no-op.
 fromNode ICU.PluralRef {}    = mempty
 fromNode (ICU.Select n x)    = case x of
-  (That w)     -> (n, TStr) : fromSelectWildcard w
-  (These cs w) -> (n, TStr) : (fromSelectCase =<< toList cs) <> fromSelectWildcard w
+  (That w)     -> (n, TStr) : (fromNode =<< w)
+  (These cs w) -> (n, TStr) : (fromSelectCase =<< toList cs) <> (fromNode =<< w)
   -- When there's no wildcard case we can compile to a union of string literals.
   (This cs)    -> (n, TStrLitUnion (fst <$> cs)) : (fromSelectCase =<< toList cs)
 fromNode (ICU.Callback n xs) = (n, TEndo) : (fromNode =<< xs)
@@ -75,6 +75,3 @@ fromRulePluralCase (_, xs) = fromNode =<< xs
 
 fromSelectCase :: ICU.SelectCase -> UncollatedArgs
 fromSelectCase (_, xs) = fromNode =<< xs
-
-fromSelectWildcard :: ICU.SelectWildcard -> UncollatedArgs
-fromSelectWildcard (ICU.SelectWildcard xs) = fromNode =<< xs

--- a/lib/Intlc/Compiler.hs
+++ b/lib/Intlc/Compiler.hs
@@ -37,7 +37,7 @@ compileTranslation l k (Translation v be _) = case be of
   TypeScriptReact -> TS.compileNamedExport JSX         l k v
 
 type ICUBool = (ICU.Stream, ICU.Stream)
-type ICUSelect = These (NonEmpty ICU.SelectCase) ICU.SelectWildcard
+type ICUSelect = These (NonEmpty ICU.SelectCase) ICU.Stream
 
 compileFlattened :: Dataset Translation -> Text
 compileFlattened = JSON.compileDataset . mapMsgs flatten
@@ -102,13 +102,10 @@ mapBoolStreams :: (ICU.Stream -> ICU.Stream) -> ICUBool -> ICUBool
 mapBoolStreams f (xs, ys) = (f xs, f ys)
 
 mapSelectStreams :: (ICU.Stream -> ICU.Stream) -> ICUSelect -> ICUSelect
-mapSelectStreams f = bimap (fmap (mapSelectCase f)) (mapSelectWildcard f)
+mapSelectStreams f = bimap (fmap (mapSelectCase f)) f
 
 mapSelectCase :: (ICU.Stream -> ICU.Stream) -> ICU.SelectCase -> ICU.SelectCase
 mapSelectCase f (x, ys) = (x, f ys)
-
-mapSelectWildcard :: (ICU.Stream -> ICU.Stream) -> ICU.SelectWildcard -> ICU.SelectWildcard
-mapSelectWildcard f (ICU.SelectWildcard xs) = ICU.SelectWildcard (f xs)
 
 mapPluralCase :: (ICU.Stream -> ICU.Stream) -> ICU.PluralCase a -> ICU.PluralCase a
 mapPluralCase f (x, ys) = (x, f ys)

--- a/lib/Intlc/Compiler.hs
+++ b/lib/Intlc/Compiler.hs
@@ -92,11 +92,11 @@ expandRules :: (Functor f, Foldable f) => f (ICU.PluralCase ICU.PluralRule) -> I
 -- `unionBy` being non-empty, namely `extraCases` - though given the complexity
 -- this is unit tested for confidence.
 expandRules ys w = fromList $ unionBy ((==) `on` caseRule) (toList ys) extraCases
-  where extraCases = flip ICU.PluralCase (wildContent w) <$> missingRules
+  where extraCases = (, wildContent w) <$> missingRules
         missingRules = filter (not . flip elem presentRules) allRules
         presentRules = caseRule <$> ys
         allRules = universe
-        caseRule (ICU.PluralCase x _) = x
+        caseRule (x, _) = x
         wildContent (ICU.PluralWildcard x) = x
 
 mapBoolStreams :: (ICU.Stream -> ICU.Stream) -> ICUBool -> ICUBool
@@ -112,7 +112,7 @@ mapSelectWildcard :: (ICU.Stream -> ICU.Stream) -> ICU.SelectWildcard -> ICU.Sel
 mapSelectWildcard f (ICU.SelectWildcard xs) = ICU.SelectWildcard (f xs)
 
 mapPluralCase :: (ICU.Stream -> ICU.Stream) -> ICU.PluralCase a -> ICU.PluralCase a
-mapPluralCase f (ICU.PluralCase x ys) = ICU.PluralCase x (f ys)
+mapPluralCase f (x, ys) = (x, f ys)
 
 mapPluralWildcard :: (ICU.Stream -> ICU.Stream) -> ICU.PluralWildcard -> ICU.PluralWildcard
 mapPluralWildcard f (ICU.PluralWildcard xs) = ICU.PluralWildcard (f xs)

--- a/lib/Intlc/Compiler.hs
+++ b/lib/Intlc/Compiler.hs
@@ -105,7 +105,7 @@ mapSelectStreams :: (ICU.Stream -> ICU.Stream) -> ICUSelect -> ICUSelect
 mapSelectStreams f = bimap (fmap (mapSelectCase f)) (mapSelectWildcard f)
 
 mapSelectCase :: (ICU.Stream -> ICU.Stream) -> ICU.SelectCase -> ICU.SelectCase
-mapSelectCase f (ICU.SelectCase x ys) = ICU.SelectCase x (f ys)
+mapSelectCase f (x, ys) = (x, f ys)
 
 mapSelectWildcard :: (ICU.Stream -> ICU.Stream) -> ICU.SelectWildcard -> ICU.SelectWildcard
 mapSelectWildcard f (ICU.SelectWildcard xs) = ICU.SelectWildcard (f xs)

--- a/lib/Intlc/Compiler.hs
+++ b/lib/Intlc/Compiler.hs
@@ -45,11 +45,11 @@ compileFlattened = JSON.compileDataset . mapMsgs flatten
 mapMsgs :: (ICU.Message -> ICU.Message) -> Dataset Translation -> Dataset Translation
 mapMsgs f = fmap $ \x -> x { message = f (message x) }
 
--- Map every token, included those nested, in a `Stream`. Order is unspecified.
--- The children of a token, if any, will be traversed after the provided
--- function is applied.
-mapTokens :: (ICU.Token -> ICU.Token) -> ICU.Stream -> ICU.Stream
-mapTokens f = fmap $ f >>> \case
+-- Map every `Node`, included those nested, in a `Stream`. Order is
+-- unspecified. The children of a node, if any, will be traversed after the
+-- provided function is applied.
+mapNodes :: (ICU.Node -> ICU.Node) -> ICU.Stream -> ICU.Stream
+mapNodes f = fmap $ f >>> \case
   ICU.Bool n xs ys  -> ICU.Bool n (f <$> xs) (f <$> ys)
   ICU.Plural n y    -> ICU.Plural n $ mapPluralStreams (fmap f) y
   ICU.Select n y    -> ICU.Select n $ mapSelectStreams (fmap f) y
@@ -74,7 +74,7 @@ flatten = ICU.Message . go [] . ICU.unMessage
 -- Added plural rules inherit the content of the wildcard. Output order of
 -- rules is unspecified.
 expandPlurals :: ICU.Message -> ICU.Message
-expandPlurals (ICU.Message xs) = ICU.Message . flip mapTokens xs $ \case
+expandPlurals (ICU.Message xs) = ICU.Message . flip mapNodes xs $ \case
   ICU.Plural n p -> ICU.Plural n $ case p of
     ICU.CardinalExact {}               -> p
     ICU.CardinalInexact exacts rules w ->

--- a/lib/Intlc/ICU.hs
+++ b/lib/Intlc/ICU.hs
@@ -3,7 +3,7 @@
 
 module Intlc.ICU where
 
-import           Prelude    hiding (Type)
+import           Prelude hiding (Type)
 
 newtype Message = Message Stream
   deriving (Show, Eq)

--- a/lib/Intlc/ICU.hs
+++ b/lib/Intlc/ICU.hs
@@ -14,6 +14,12 @@ unMessage (Message xs) = xs
 
 type Stream = [Token]
 
+newtype Arg = Arg Text
+  deriving (Show, Eq, Ord, IsString)
+
+unArg :: Arg -> Text
+unArg (Arg x) = x
+
 -- | A token is either an interpolation - some sort of identifier for input -
 -- or mere plaintext. A collection of tokens make up any message. A non-empty
 -- message without any interpolation will be a single `Plaintext` token.
@@ -22,17 +28,17 @@ type Stream = [Token]
 -- not necessarily requiring wildcard cases.
 data Token
   = Plaintext Text
-  | Bool { name :: Text, trueCase :: Stream, falseCase :: Stream }
-  | String Text
-  | Number Text
-  | Date Text DateTimeFmt
-  | Time Text DateTimeFmt
-  | Plural Text Plural
+  | Bool { name :: Arg, trueCase :: Stream, falseCase :: Stream }
+  | String Arg
+  | Number Arg
+  | Date Arg DateTimeFmt
+  | Time Arg DateTimeFmt
+  | Plural Arg Plural
   -- Plural hash references have their own distinct type rather than merely
   -- taking on `Number` to allow compilers to infer appropriately.
-  | PluralRef Text
-  | Select Text (These (NonEmpty SelectCase) SelectWildcard)
-  | Callback Text Stream
+  | PluralRef Arg
+  | Select Arg (These (NonEmpty SelectCase) SelectWildcard)
+  | Callback Arg Stream
   deriving (Show, Eq)
 
 data DateTimeFmt
@@ -92,7 +98,7 @@ mergePlaintext (x:ys)                           = x : mergePlaintext ys
 getStream :: Token -> Maybe Stream
 getStream = fmap snd . getNamedStream
 
-getNamedStream :: Token -> Maybe (Text, Stream)
+getNamedStream :: Token -> Maybe (Arg, Stream)
 getNamedStream Plaintext {}    = Nothing
 getNamedStream String {}       = Nothing
 getNamedStream Number {}       = Nothing

--- a/lib/Intlc/ICU.hs
+++ b/lib/Intlc/ICU.hs
@@ -75,8 +75,7 @@ data PluralRule
   | Many
   deriving (Show, Eq, Ord, Enum, Bounded)
 
-data SelectCase = SelectCase Text Stream
-  deriving (Show, Eq)
+type SelectCase = (Text, Stream)
 
 newtype SelectWildcard = SelectWildcard Stream
   deriving (Show, Eq)
@@ -109,9 +108,8 @@ getNamedStream (Ordinal n xs ys w)         = Just . (n,) $ mconcat
   , getPluralCaseStream `concatMap` ys
   , w
   ]
-getNamedStream (Select n x)    = Just . (n,) . bifoldMap (concatMap f) g $ x
-    where f (SelectCase _ xs)  = xs
-          g (SelectWildcard w) = w
+getNamedStream (Select n x)    = Just . (n,) . bifoldMap (concatMap snd) f $ x
+    where f (SelectWildcard w) = w
 getNamedStream (Callback n xs) = Just (n, xs)
 
 getPluralCaseStream :: PluralCase a -> Stream

--- a/lib/Intlc/ICU.hs
+++ b/lib/Intlc/ICU.hs
@@ -47,7 +47,7 @@ data Node
   -- Plural hash references have their own distinct type rather than merely
   -- taking on `Number` to allow compilers to infer appropriately.
   | PluralRef Arg
-  | Select Arg (These (NonEmpty SelectCase) SelectWildcard)
+  | Select Arg (These (NonEmpty SelectCase) Stream)
   | Callback Arg Stream
   deriving (Show, Eq)
 
@@ -77,9 +77,6 @@ data PluralRule
 
 type SelectCase = (Text, Stream)
 
-newtype SelectWildcard = SelectWildcard Stream
-  deriving (Show, Eq)
-
 -- | Merges any sibling `Plaintext` nodes in a `Stream`.
 mergePlaintext :: Stream -> Stream
 mergePlaintext []                               = []
@@ -108,8 +105,7 @@ getNamedStream (Ordinal n xs ys w)         = Just . (n,) $ mconcat
   , getPluralCaseStream `concatMap` ys
   , w
   ]
-getNamedStream (Select n x)    = Just . (n,) . bifoldMap (concatMap snd) f $ x
-    where f (SelectWildcard w) = w
+getNamedStream (Select n x)    = Just . (n,) . bifoldMap (concatMap snd) id $ x
 getNamedStream (Callback n xs) = Just (n, xs)
 
 getPluralCaseStream :: PluralCase a -> Stream

--- a/lib/Intlc/ICU.hs
+++ b/lib/Intlc/ICU.hs
@@ -12,7 +12,7 @@ newtype Message = Message Stream
 unMessage :: Message -> Stream
 unMessage (Message xs) = xs
 
-type Stream = [Token]
+type Stream = [Node]
 
 newtype Arg = Arg Text
   deriving (Show, Eq, Ord, IsString)
@@ -20,13 +20,13 @@ newtype Arg = Arg Text
 unArg :: Arg -> Text
 unArg (Arg x) = x
 
--- | A token is either an interpolation - some sort of identifier for input -
--- or mere plaintext. A collection of tokens make up any message. A non-empty
--- message without any interpolation will be a single `Plaintext` token.
+-- | A `Node` is either an interpolation - some sort of identifier for input -
+-- or mere plaintext. A collection of nodes make up any message. A non-empty
+-- message without any interpolation will be a single `Plaintext` node.
 --
 -- On interpolations we diverge from icu4j by supporting a boolean type, and
 -- not necessarily requiring wildcard cases.
-data Token
+data Node
   = Plaintext Text
   | Bool { name :: Arg, trueCase :: Stream, falseCase :: Stream }
   | String Arg
@@ -89,16 +89,16 @@ data SelectCase = SelectCase Text Stream
 newtype SelectWildcard = SelectWildcard Stream
   deriving (Show, Eq)
 
--- | Merges any sibling `Plaintext` tokens in a `Stream`.
+-- | Merges any sibling `Plaintext` nodes in a `Stream`.
 mergePlaintext :: Stream -> Stream
 mergePlaintext []                               = []
 mergePlaintext (Plaintext x : Plaintext y : zs) = mergePlaintext $ Plaintext (x <> y) : zs
 mergePlaintext (x:ys)                           = x : mergePlaintext ys
 
-getStream :: Token -> Maybe Stream
+getStream :: Node -> Maybe Stream
 getStream = fmap snd . getNamedStream
 
-getNamedStream :: Token -> Maybe (Arg, Stream)
+getNamedStream :: Node -> Maybe (Arg, Stream)
 getNamedStream Plaintext {}    = Nothing
 getNamedStream String {}       = Nothing
 getNamedStream Number {}       = Nothing

--- a/lib/Intlc/ICU.hs
+++ b/lib/Intlc/ICU.hs
@@ -58,8 +58,7 @@ data DateTimeFmt
   | Full
   deriving (Show, Eq)
 
-data PluralCase a = PluralCase a Stream
-  deriving (Show, Eq)
+type PluralCase a = (a, Stream)
 
 -- `Text` here is our count. It's represented as a string so that we can dump
 -- it back out without thinking about converting numeric types across
@@ -119,7 +118,7 @@ getNamedStream (Select n x)    = Just . (n,) . bifoldMap (concatMap f) g $ x
 getNamedStream (Callback n xs) = Just (n, xs)
 
 getPluralCaseStream :: PluralCase a -> Stream
-getPluralCaseStream (PluralCase _ xs) = xs
+getPluralCaseStream = snd
 
 getPluralWildcardStream :: PluralWildcard -> Stream
 getPluralWildcardStream (PluralWildcard xs) = xs

--- a/lib/Intlc/Linter.hs
+++ b/lib/Intlc/Linter.hs
@@ -100,11 +100,9 @@ redundantPluralRule = fmap RedundantPlural . nonEmpty . idents where
     , maybeToMonoid (idents <$> getStream x)
     , idents xs
     ]
-  redundantIdent (Plural n p) = case p of
-    CardinalInexact [] [] _ -> Just n
-    Ordinal [] [] _         -> Just n
-    _                       -> Nothing
-  redundantIdent _            = Nothing
+  redundantIdent (CardinalInexact n [] [] _) = Just n
+  redundantIdent (Ordinal n [] [] _)         = Just n
+  redundantIdent _                                 = Nothing
 
 -- Our translation vendor has poor support for ICU syntax, and their parser
 -- particularly struggles with interpolations. This rule limits the use of these
@@ -121,10 +119,12 @@ interpolationsRule = count . complexIdents where
   -- however we exclude callbacks and plurals from this. The former because
   -- the vendor's tool has no issues parsing its syntax and the latter
   -- because it's a special case that we can't rewrite.
-  getComplexStream Callback {}  = Nothing
-  getComplexStream Plural {}    = Nothing
-  getComplexStream Plaintext {} = Nothing
-  getComplexStream x            = getNamedStream x
+  getComplexStream Callback {}              = Nothing
+  getComplexStream CardinalExact {}   = Nothing
+  getComplexStream CardinalInexact {} = Nothing
+  getComplexStream Ordinal {}         = Nothing
+  getComplexStream Plaintext {}             = Nothing
+  getComplexStream x                        = getNamedStream x
 
 -- Allows any ASCII character as well as a handful of Unicode characters that
 -- we've established are safe for use with our vendor's tool.

--- a/lib/Intlc/Linter.hs
+++ b/lib/Intlc/Linter.hs
@@ -124,7 +124,7 @@ interpolationsRule = count . complexIdents where
   getComplexStream Callback {}  = Nothing
   getComplexStream Plural {}    = Nothing
   getComplexStream Plaintext {} = Nothing
-  getComplexStream token        = getNamedStream token
+  getComplexStream x            = getNamedStream x
 
 -- Allows any ASCII character as well as a handful of Unicode characters that
 -- we've established are safe for use with our vendor's tool.

--- a/lib/Intlc/Linter.hs
+++ b/lib/Intlc/Linter.hs
@@ -101,7 +101,7 @@ redundantPluralRule = fmap RedundantPlural . nonEmpty . idents where
     ]
   redundantIdent (CardinalInexact n [] [] _) = Just n
   redundantIdent (Ordinal n [] [] _)         = Just n
-  redundantIdent _                                 = Nothing
+  redundantIdent _                           = Nothing
 
 -- Our translation vendor has poor support for ICU syntax, and their parser
 -- particularly struggles with interpolations. This rule limits the use of these
@@ -118,12 +118,12 @@ interpolationsRule = count . complexIdents where
   -- however we exclude callbacks and plurals from this. The former because
   -- the vendor's tool has no issues parsing its syntax and the latter
   -- because it's a special case that we can't rewrite.
-  getComplexStream Callback {}              = Nothing
+  getComplexStream Callback {}        = Nothing
   getComplexStream CardinalExact {}   = Nothing
   getComplexStream CardinalInexact {} = Nothing
   getComplexStream Ordinal {}         = Nothing
-  getComplexStream Plaintext {}             = Nothing
-  getComplexStream x                        = getNamedStream x
+  getComplexStream Plaintext {}       = Nothing
+  getComplexStream x                  = getNamedStream x
 
 -- Allows any ASCII character as well as a handful of Unicode characters that
 -- we've established are safe for use with our vendor's tool.

--- a/lib/Intlc/Linter.hs
+++ b/lib/Intlc/Linter.hs
@@ -5,7 +5,6 @@ import qualified Data.Text           as T
 import           Control.Monad.Extra (pureIf)
 import           Data.Char           (isAscii)
 import qualified Data.Map            as M
-import           Data.These          (These (..))
 import           Intlc.Core
 import           Intlc.ICU
 import           Prelude
@@ -86,8 +85,8 @@ redundantSelectRule = fmap RedundantSelect . nonEmpty . idents where
     , maybeToMonoid (idents <$> getStream x)
     , idents xs
     ]
-  redundantIdent (Select n (That _w)) = Just n
-  redundantIdent _                    = Nothing
+  redundantIdent (SelectWild n _w) = Just n
+  redundantIdent _                 = Nothing
 
 -- Plural interpolations with only wildcards are redundant: they could be
 -- replaced with plain number interpolations.

--- a/lib/Intlc/Parser/Error.hs
+++ b/lib/Intlc/Parser/Error.hs
@@ -5,6 +5,7 @@
 module Intlc.Parser.Error where
 
 import qualified Data.Text                     as T
+import           Intlc.ICU                     (Arg, unArg)
 import           Prelude
 import           Text.Megaparsec               (MonadParsec (parseError))
 import           Text.Megaparsec.Error
@@ -22,9 +23,9 @@ data JSONParseErr
   deriving (Show, Eq, Ord)
 
 data MessageParseErr
-  = NoClosingCallbackTag Text
-  | BadClosingCallbackTag Text Text
-  | NoOpeningCallbackTag Text
+  = NoClosingCallbackTag Arg
+  | BadClosingCallbackTag Arg Arg
+  | NoOpeningCallbackTag Arg
   deriving (Show, Eq, Ord)
 
 instance ShowErrorComponent ParseErr where
@@ -35,9 +36,9 @@ instance ShowErrorComponent JSONParseErr where
   showErrorComponent (DuplicateKey k) = "Duplicate key: \"" <> T.unpack k <> "\""
 
 instance ShowErrorComponent MessageParseErr where
-  showErrorComponent (NoClosingCallbackTag x)    = "Callback tag <" <> T.unpack x <> "> not closed"
-  showErrorComponent (BadClosingCallbackTag x y) = "Callback tag <" <> T.unpack x <> "> not closed, instead found </" <> T.unpack y <> ">"
-  showErrorComponent (NoOpeningCallbackTag x)    = "Callback tag </" <> T.unpack x <> "> not opened"
+  showErrorComponent (NoClosingCallbackTag x)    = "Callback tag <" <> T.unpack (unArg x) <> "> not closed"
+  showErrorComponent (BadClosingCallbackTag x y) = "Callback tag <" <> T.unpack (unArg x) <> "> not closed, instead found </" <> T.unpack (unArg y) <> ">"
+  showErrorComponent (NoOpeningCallbackTag x)    = "Callback tag </" <> T.unpack (unArg x) <> "> not opened"
 
 failingWith :: MonadParsec e s m => Int -> e -> m a
 pos `failingWith` e = parseError . errFancy pos . fancy . ErrorCustom $ e

--- a/lib/Intlc/Parser/ICU.hs
+++ b/lib/Intlc/Parser/ICU.hs
@@ -201,5 +201,5 @@ pluralRule = choice
   , Many <$ string "many"
   ]
 
-pluralWildcard :: Parser PluralWildcard
-pluralWildcard = PluralWildcard <$> (string "other" *> hspace1 *> caseBody)
+pluralWildcard :: Parser Stream
+pluralWildcard = string "other" *> hspace1 *> caseBody

--- a/lib/Intlc/Parser/ICU.hs
+++ b/lib/Intlc/Parser/ICU.hs
@@ -186,11 +186,11 @@ mixedPluralCases :: Parser ([PluralCase PluralExact], [PluralCase PluralRule])
 mixedPluralCases = partitionEithers <$> sepEndBy (eitherP pluralExactCase pluralRuleCase) hspace1
 
 pluralExactCase :: Parser (PluralCase PluralExact)
-pluralExactCase = PluralCase <$> pluralExact <* hspace1 <*> caseBody
+pluralExactCase = (,) <$> pluralExact <* hspace1 <*> caseBody
   where pluralExact = PluralExact . T.pack <$> (string "=" *> some numberChar)
 
 pluralRuleCase :: Parser (PluralCase PluralRule)
-pluralRuleCase = PluralCase <$> pluralRule <* hspace1 <*> caseBody
+pluralRuleCase = (,) <$> pluralRule <* hspace1 <*> caseBody
 
 pluralRule :: Parser PluralRule
 pluralRule = choice

--- a/lib/Intlc/Parser/ICU.hs
+++ b/lib/Intlc/Parser/ICU.hs
@@ -163,7 +163,7 @@ selectCases = choice
   [ reconcile <$> cases <*> optional wildcard
   , That <$> wildcard
   ]
-  where cases = NE.sepEndBy1 (SelectCase <$> (name <* hspace1) <*> caseBody) hspace1
+  where cases = NE.sepEndBy1 ((,) <$> (name <* hspace1) <*> caseBody) hspace1
         wildcard = SelectWildcard <$> (string wildcardName *> hspace1 *> caseBody)
         reconcile cs (Just w) = These cs w
         reconcile cs Nothing  = This cs

--- a/lib/Intlc/Parser/ICU.hs
+++ b/lib/Intlc/Parser/ICU.hs
@@ -158,13 +158,13 @@ boolCases = (,)
    <* hspace1
   <*> (string "false" *> hspace1 *> caseBody)
 
-selectCases :: Parser (These (NonEmpty SelectCase) SelectWildcard)
+selectCases :: Parser (These (NonEmpty SelectCase) Stream)
 selectCases = choice
   [ reconcile <$> cases <*> optional wildcard
   , That <$> wildcard
   ]
   where cases = NE.sepEndBy1 ((,) <$> (name <* hspace1) <*> caseBody) hspace1
-        wildcard = SelectWildcard <$> (string wildcardName *> hspace1 *> caseBody)
+        wildcard = string wildcardName *> hspace1 *> caseBody
         reconcile cs (Just w) = These cs w
         reconcile cs Nothing  = This cs
         name = try $ mfilter (/= wildcardName) ident

--- a/lib/Intlc/Parser/JSON.hs
+++ b/lib/Intlc/Parser/JSON.hs
@@ -20,8 +20,8 @@ import           Intlc.Parser.Error               (JSONParseErr (..),
                                                    failingWith)
 import qualified Intlc.Parser.ICU                 as ICUP
 import           Prelude                          hiding (null)
-import           Text.Megaparsec                  hiding (State, Stream,
-                                                   many, some)
+import           Text.Megaparsec                  hiding (State, Stream, many,
+                                                   some)
 import           Text.Megaparsec.Char
 import qualified Text.Megaparsec.Char.Lexer       as L
 import           Text.Megaparsec.Error.Builder    (errFancy, fancy)

--- a/lib/Intlc/Parser/JSON.hs
+++ b/lib/Intlc/Parser/JSON.hs
@@ -3,8 +3,8 @@
 -- Aeson limitations.
 --
 -- This module follows the following whitespace rules:
---   * Consume all whitespace after tokens where possible.
---   * Therefore, assume no whitespace before tokens.
+--   * Consume all whitespace after nodes where possible.
+--   * Therefore, assume no whitespace before nodes.
 
 module Intlc.Parser.JSON where
 
@@ -20,8 +20,8 @@ import           Intlc.Parser.Error               (JSONParseErr (..),
                                                    failingWith)
 import qualified Intlc.Parser.ICU                 as ICUP
 import           Prelude                          hiding (null)
-import           Text.Megaparsec                  hiding (State, Stream, Token,
-                                                   many, some, token)
+import           Text.Megaparsec                  hiding (State, Stream,
+                                                   many, some)
 import           Text.Megaparsec.Char
 import qualified Text.Megaparsec.Char.Lexer       as L
 import           Text.Megaparsec.Error.Builder    (errFancy, fancy)

--- a/test/Intlc/Backend/TypeScriptSpec.hs
+++ b/test/Intlc/Backend/TypeScriptSpec.hs
@@ -37,8 +37,8 @@ spec = describe "TypeScript compiler" $ do
           , ICU.Plaintext "! You are "
           , ICU.CardinalInexact
               "age"
-              (pure (ICU.PluralCase (ICU.PluralExact "42") (pure (ICU.Plaintext "very cool"))))
-              (pure (ICU.PluralCase ICU.Zero (pure (ICU.Plaintext "new around here"))))
+              (pure (ICU.PluralExact "42", pure (ICU.Plaintext "very cool")))
+              (pure (ICU.Zero, pure (ICU.Plaintext "new around here")))
               (ICU.PluralWildcard (pure (ICU.Plaintext "not all that interesting")))
           , ICU.Plaintext ". Regardless, the magic number is most certainly "
           , ICU.Number "magicNumber"
@@ -114,7 +114,7 @@ spec = describe "TypeScript compiler" $ do
 
     it "in cardinal plural" $ do
       let x = ICU.CardinalExact "x" . pure $
-                ICU.PluralCase (ICU.PluralExact "42") [ICU.String "y"]
+                (ICU.PluralExact "42", [ICU.String "y"])
       let ys =
               [ ("x", pure (TS.TNumLitUnion (pure "42")))
               , ("y", pure TS.TStr)
@@ -123,8 +123,8 @@ spec = describe "TypeScript compiler" $ do
 
     it "in ordinal plural" $ do
       let x = ICU.Ordinal "x"
-                [ICU.PluralCase (ICU.PluralExact "42") [ICU.Date "foo" ICU.Short]]
-                (pure $ ICU.PluralCase ICU.Few [ICU.String "bar"])
+                [(ICU.PluralExact "42", [ICU.Date "foo" ICU.Short])]
+                (pure (ICU.Few, [ICU.String "bar"]))
                 (ICU.PluralWildcard [ICU.Number "baz"])
       let ys =
               [ ("x", pure TS.TNum)

--- a/test/Intlc/Backend/TypeScriptSpec.hs
+++ b/test/Intlc/Backend/TypeScriptSpec.hs
@@ -48,8 +48,8 @@ spec = describe "TypeScript compiler" $ do
           , ICU.Time "currTime" ICU.Full
           , ICU.Plaintext ". And just to recap, your name is "
           , ICU.Select "name" . This . fromList $
-              [ ICU.SelectCase "Sam" [ICU.Plaintext "undoubtedly excellent"]
-              , ICU.SelectCase "Ashley" [ICU.Plaintext "fairly good"]
+              [ ("Sam", [ICU.Plaintext "undoubtedly excellent"])
+              , ("Ashley", [ICU.Plaintext "fairly good"])
               ]
           , ICU.Plaintext ". Finally, you are "
           , ICU.Bool
@@ -92,12 +92,12 @@ spec = describe "TypeScript compiler" $ do
     it "typechecks nested selects" $ do
       golden TemplateLit (compileNamedExport TemplateLit (Locale "te-ST") "test") "nested-select" $
         ICU.Message [ICU.Select "x" . This $ fromList
-          [ ICU.SelectCase "a" []
-          , ICU.SelectCase "b" [ICU.Select "x" . This $ fromList
-            [ ICU.SelectCase "a" [] -- <-- without a workaround, TypeScript will have narrowed and reject this case
-            , ICU.SelectCase "b" []
+          [ ("a", [])
+          , ("b", [ICU.Select "x" . This $ fromList
+            [ ("a", []) -- <-- without a workaround, TypeScript will have narrowed and reject this case
+            , ("b", [])
             ]]
-          ]]
+          )]]
 
   describe "collects nested arguments" $ do
     let args (TS.Lambda xs _) = xs
@@ -105,7 +105,7 @@ spec = describe "TypeScript compiler" $ do
     let fromArgs = fromList
 
     it "in select" $ do
-      let x = ICU.Select "x" . This . pure $ ICU.SelectCase "foo" [ICU.String "y"]
+      let x = ICU.Select "x" . This . pure $ ("foo", [ICU.String "y"])
       let ys =
               [ ("x", pure (TS.TStrLitUnion (pure "foo")))
               , ("y", pure TS.TStr)

--- a/test/Intlc/Backend/TypeScriptSpec.hs
+++ b/test/Intlc/Backend/TypeScriptSpec.hs
@@ -39,7 +39,7 @@ spec = describe "TypeScript compiler" $ do
               "age"
               (pure (ICU.PluralExact "42", pure (ICU.Plaintext "very cool")))
               (pure (ICU.Zero, pure (ICU.Plaintext "new around here")))
-              (ICU.PluralWildcard (pure (ICU.Plaintext "not all that interesting")))
+            (pure (ICU.Plaintext "not all that interesting"))
           , ICU.Plaintext ". Regardless, the magic number is most certainly "
           , ICU.Number "magicNumber"
           , ICU.Plaintext "! The date is "
@@ -125,7 +125,7 @@ spec = describe "TypeScript compiler" $ do
       let x = ICU.Ordinal "x"
                 [(ICU.PluralExact "42", [ICU.Date "foo" ICU.Short])]
                 (pure (ICU.Few, [ICU.String "bar"]))
-                (ICU.PluralWildcard [ICU.Number "baz"])
+                [ICU.Number "baz"]
       let ys =
               [ ("x", pure TS.TNum)
               , ("foo", pure TS.TDate)

--- a/test/Intlc/Backend/TypeScriptSpec.hs
+++ b/test/Intlc/Backend/TypeScriptSpec.hs
@@ -102,7 +102,7 @@ spec = describe "TypeScript compiler" $ do
 
   describe "collects nested arguments" $ do
     let args (TS.Lambda xs _) = xs
-    let fromToken = args . TS.fromMsg TS.TFragment . ICU.Message . pure
+    let fromNode = args . TS.fromMsg TS.TFragment . ICU.Message . pure
     let fromArgs = fromList
 
     it "in select" $ do
@@ -111,7 +111,7 @@ spec = describe "TypeScript compiler" $ do
               [ ("x", pure (TS.TStrLitUnion (pure "foo")))
               , ("y", pure TS.TStr)
               ]
-      fromToken x `shouldBe` fromArgs ys
+      fromNode x `shouldBe` fromArgs ys
 
     it "in cardinal plural" $ do
       let x = ICU.Plural "x" . ICU.CardinalExact . pure $
@@ -120,7 +120,7 @@ spec = describe "TypeScript compiler" $ do
               [ ("x", pure (TS.TNumLitUnion (pure "42")))
               , ("y", pure TS.TStr)
               ]
-      fromToken x `shouldBe` fromArgs ys
+      fromNode x `shouldBe` fromArgs ys
 
     it "in ordinal plural" $ do
       let x = ICU.Plural "x" $ ICU.Ordinal
@@ -133,7 +133,7 @@ spec = describe "TypeScript compiler" $ do
               , ("bar", pure TS.TStr)
               , ("baz", pure TS.TNum)
               ]
-      fromToken x `shouldBe` fromArgs ys
+      fromNode x `shouldBe` fromArgs ys
 
     it "in boolean" $ do
       let x = ICU.Bool "x"
@@ -144,4 +144,4 @@ spec = describe "TypeScript compiler" $ do
               , ("y", pure TS.TStr)
               , ("z", pure TS.TNum)
               ]
-      fromToken x `shouldBe` fromArgs ys
+      fromNode x `shouldBe` fromArgs ys

--- a/test/Intlc/Backend/TypeScriptSpec.hs
+++ b/test/Intlc/Backend/TypeScriptSpec.hs
@@ -1,7 +1,6 @@
 module Intlc.Backend.TypeScriptSpec (spec) where
 
 import qualified Data.Text                         as T
-import           Data.These                        (These (..))
 import           Intlc.Backend.JavaScript.Compiler (InterpStrat (..))
 import           Intlc.Backend.TypeScript.Compiler (compileNamedExport,
                                                     compileTypeof)
@@ -47,7 +46,7 @@ spec = describe "TypeScript compiler" $ do
           , ICU.Plaintext ", and the time is "
           , ICU.Time "currTime" ICU.Full
           , ICU.Plaintext ". And just to recap, your name is "
-          , ICU.Select "name" . This . fromList $
+          , ICU.SelectNamed "name" . fromList $
               [ ("Sam", [ICU.Plaintext "undoubtedly excellent"])
               , ("Ashley", [ICU.Plaintext "fairly good"])
               ]
@@ -91,9 +90,9 @@ spec = describe "TypeScript compiler" $ do
     -- Typechecking happens externally.
     it "typechecks nested selects" $ do
       golden TemplateLit (compileNamedExport TemplateLit (Locale "te-ST") "test") "nested-select" $
-        ICU.Message [ICU.Select "x" . This $ fromList
+        ICU.Message [ICU.SelectNamed "x" $ fromList
           [ ("a", [])
-          , ("b", [ICU.Select "x" . This $ fromList
+          , ("b", [ICU.SelectNamed "x" $ fromList
             [ ("a", []) -- <-- without a workaround, TypeScript will have narrowed and reject this case
             , ("b", [])
             ]]
@@ -105,7 +104,7 @@ spec = describe "TypeScript compiler" $ do
     let fromArgs = fromList
 
     it "in select" $ do
-      let x = ICU.Select "x" . This . pure $ ("foo", [ICU.String "y"])
+      let x = ICU.SelectNamed "x" . pure $ ("foo", [ICU.String "y"])
       let ys =
               [ ("x", pure (TS.TStrLitUnion (pure "foo")))
               , ("y", pure TS.TStr)

--- a/test/Intlc/Backend/TypeScriptSpec.hs
+++ b/test/Intlc/Backend/TypeScriptSpec.hs
@@ -35,12 +35,11 @@ spec = describe "TypeScript compiler" $ do
               ICU.String "name"
             )
           , ICU.Plaintext "! You are "
-          , ICU.Plural "age"
-              (ICU.CardinalInexact
-                (pure (ICU.PluralCase (ICU.PluralExact "42") (pure (ICU.Plaintext "very cool"))))
-                (pure (ICU.PluralCase ICU.Zero (pure (ICU.Plaintext "new around here"))))
-                (ICU.PluralWildcard (pure (ICU.Plaintext "not all that interesting")))
-              )
+          , ICU.CardinalInexact
+              "age"
+              (pure (ICU.PluralCase (ICU.PluralExact "42") (pure (ICU.Plaintext "very cool"))))
+              (pure (ICU.PluralCase ICU.Zero (pure (ICU.Plaintext "new around here"))))
+              (ICU.PluralWildcard (pure (ICU.Plaintext "not all that interesting")))
           , ICU.Plaintext ". Regardless, the magic number is most certainly "
           , ICU.Number "magicNumber"
           , ICU.Plaintext "! The date is "
@@ -114,7 +113,7 @@ spec = describe "TypeScript compiler" $ do
       fromNode x `shouldBe` fromArgs ys
 
     it "in cardinal plural" $ do
-      let x = ICU.Plural "x" . ICU.CardinalExact . pure $
+      let x = ICU.CardinalExact "x" . pure $
                 ICU.PluralCase (ICU.PluralExact "42") [ICU.String "y"]
       let ys =
               [ ("x", pure (TS.TNumLitUnion (pure "42")))
@@ -123,7 +122,7 @@ spec = describe "TypeScript compiler" $ do
       fromNode x `shouldBe` fromArgs ys
 
     it "in ordinal plural" $ do
-      let x = ICU.Plural "x" $ ICU.Ordinal
+      let x = ICU.Ordinal "x"
                 [ICU.PluralCase (ICU.PluralExact "42") [ICU.Date "foo" ICU.Short]]
                 (pure $ ICU.PluralCase ICU.Few [ICU.String "bar"])
                 (ICU.PluralWildcard [ICU.Number "baz"])

--- a/test/Intlc/CompilerSpec.hs
+++ b/test/Intlc/CompilerSpec.hs
@@ -60,8 +60,8 @@ spec = describe "compiler" $ do
     it "flattens shallow plural" $ do
       let other = PluralWildcard [Plaintext "many dogs"]
       let otherf = PluralWildcard [Plaintext "I have many dogs"]
-      let one = PluralCase One [Plaintext "a dog"]
-      let onef = PluralCase One [Plaintext "I have a dog"]
+      let one = (One, [Plaintext "a dog"])
+      let onef = (One, [Plaintext "I have a dog"])
 
       flatten (Message [Plaintext "I have ", CardinalInexact "count" [] (pure one) other]) `shouldBe`
         Message (pure $ CardinalInexact "count" [] (pure onef) otherf)
@@ -71,7 +71,7 @@ spec = describe "compiler" $ do
             [ Plaintext "I have "
             , CardinalInexact "count"
               []
-              (pure $ PluralCase One [Plaintext "a dog"])
+              (pure (One, [Plaintext "a dog"]))
               (PluralWildcard
                 [ Number "count"
                 , Plaintext " dogs, the newest of which is "
@@ -85,7 +85,7 @@ spec = describe "compiler" $ do
       let y = Message . pure $
             CardinalInexact "count"
               []
-              (pure $ PluralCase One [Plaintext "I have a dog!"])
+              (pure (One, [Plaintext "I have a dog!"]))
               (PluralWildcard
                 [ Select "name" $ These
                   (pure $ SelectCase "hodor"
@@ -109,9 +109,9 @@ spec = describe "compiler" $ do
     let f = expandRules
 
     it "always contains every rule in the output" $ do
-      let c = PluralCase
+      let c = (,)
       let w = PluralWildcard mempty
-      let rule (PluralCase x _) = x
+      let rule (x, _) = x
       let g xs = sort (toList $ rule <$> f xs w)
 
       g [] `shouldBe` universe
@@ -120,7 +120,7 @@ spec = describe "compiler" $ do
 
     it "copies the wildcard stream to new rules" $ do
       let xs = [Plaintext "foo"]
-      let c = PluralCase
+      let c = (,)
       let w = PluralWildcard
       let g ys = toList (f ys (w xs))
 
@@ -130,7 +130,7 @@ spec = describe "compiler" $ do
         [c Many [Plaintext "bar"], c Zero mempty, c One xs, c Two xs, c Few xs]
 
     it "returns full list of rules unmodified (as non-empty)" $ do
-      let c x y = PluralCase x [Plaintext y]
+      let c x y = (x, [Plaintext y])
       let xs = [c Two "foo", c Many "", c Zero "bar", c One "baz", c Few ""]
 
       f xs (PluralWildcard [Plaintext "any"]) `shouldBe` fromList xs

--- a/test/Intlc/CompilerSpec.hs
+++ b/test/Intlc/CompilerSpec.hs
@@ -47,8 +47,8 @@ spec = describe "compiler" $ do
       let foof = ("foo", [Plaintext "I have a dog"])
 
       it "with a wildcard" $ do
-        let other = SelectWildcard [Plaintext "many dogs"]
-        let otherf = SelectWildcard [Plaintext "I have many dogs"]
+        let other = [Plaintext "many dogs"]
+        let otherf = [Plaintext "I have many dogs"]
 
         flatten (Message [Plaintext "I have ", Select "thing" $ These (pure foo) other]) `shouldBe`
           Message (pure . Select "thing" $ These (pure foof) otherf)
@@ -76,7 +76,7 @@ spec = describe "compiler" $ do
               , Plaintext " dogs, the newest of which is "
               , Select "name" $ These
                 (pure ("hodor", [Plaintext "Hodor"]))
-                (SelectWildcard [Plaintext "unknown"])
+                [Plaintext "unknown"]
               ]
             , Plaintext "!"
             ]
@@ -91,12 +91,10 @@ spec = describe "compiler" $ do
                   , Plaintext " dogs, the newest of which is Hodor!"
                   ]
                 ))
-                (SelectWildcard
-                  [ Plaintext "I have "
-                  , Number "count"
-                  , Plaintext " dogs, the newest of which is unknown!"
-                  ]
-                )
+                [ Plaintext "I have "
+                , Number "count"
+                , Plaintext " dogs, the newest of which is unknown!"
+                ]
               ]
 
       flatten x `shouldBe` y

--- a/test/Intlc/CompilerSpec.hs
+++ b/test/Intlc/CompilerSpec.hs
@@ -63,13 +63,13 @@ spec = describe "compiler" $ do
       let one = PluralCase One [Plaintext "a dog"]
       let onef = PluralCase One [Plaintext "I have a dog"]
 
-      flatten (Message [Plaintext "I have ", Plural "count" (CardinalInexact [] (pure one) other)]) `shouldBe`
-        Message (pure $ Plural "count" (CardinalInexact [] (pure onef) otherf))
+      flatten (Message [Plaintext "I have ", CardinalInexact "count" [] (pure one) other]) `shouldBe`
+        Message (pure $ CardinalInexact "count" [] (pure onef) otherf)
 
     it "flattens deep interpolations" $ do
       let x = Message
             [ Plaintext "I have "
-            , Plural "count" $ CardinalInexact
+            , CardinalInexact "count"
               []
               (pure $ PluralCase One [Plaintext "a dog"])
               (PluralWildcard
@@ -83,7 +83,7 @@ spec = describe "compiler" $ do
             , Plaintext "!"
             ]
       let y = Message . pure $
-            Plural "count" $ CardinalInexact
+            CardinalInexact "count"
               []
               (pure $ PluralCase One [Plaintext "I have a dog!"])
               (PluralWildcard

--- a/test/Intlc/CompilerSpec.hs
+++ b/test/Intlc/CompilerSpec.hs
@@ -58,8 +58,8 @@ spec = describe "compiler" $ do
           Message (pure . Select "thing" $ This (pure foof))
 
     it "flattens shallow plural" $ do
-      let other = PluralWildcard [Plaintext "many dogs"]
-      let otherf = PluralWildcard [Plaintext "I have many dogs"]
+      let other = [Plaintext "many dogs"]
+      let otherf = [Plaintext "I have many dogs"]
       let one = (One, [Plaintext "a dog"])
       let onef = (One, [Plaintext "I have a dog"])
 
@@ -72,36 +72,32 @@ spec = describe "compiler" $ do
             , CardinalInexact "count"
               []
               (pure (One, [Plaintext "a dog"]))
-              (PluralWildcard
-                [ Number "count"
-                , Plaintext " dogs, the newest of which is "
-                , Select "name" $ These
-                  (pure $ SelectCase "hodor" [Plaintext "Hodor"])
-                  (SelectWildcard [Plaintext "unknown"])
-                ]
-              )
+              [ Number "count"
+              , Plaintext " dogs, the newest of which is "
+              , Select "name" $ These
+                (pure $ SelectCase "hodor" [Plaintext "Hodor"])
+                (SelectWildcard [Plaintext "unknown"])
+              ]
             , Plaintext "!"
             ]
       let y = Message . pure $
             CardinalInexact "count"
               []
               (pure (One, [Plaintext "I have a dog!"]))
-              (PluralWildcard
-                [ Select "name" $ These
-                  (pure $ SelectCase "hodor"
-                    [ Plaintext "I have "
-                    , Number "count"
-                    , Plaintext " dogs, the newest of which is Hodor!"
-                    ]
-                  )
-                  (SelectWildcard
-                    [ Plaintext "I have "
-                    , Number "count"
-                    , Plaintext " dogs, the newest of which is unknown!"
-                    ]
-                  )
-                ]
-              )
+              [ Select "name" $ These
+                (pure $ SelectCase "hodor"
+                  [ Plaintext "I have "
+                  , Number "count"
+                  , Plaintext " dogs, the newest of which is Hodor!"
+                  ]
+                )
+                (SelectWildcard
+                  [ Plaintext "I have "
+                  , Number "count"
+                  , Plaintext " dogs, the newest of which is unknown!"
+                  ]
+                )
+              ]
 
       flatten x `shouldBe` y
 
@@ -110,7 +106,7 @@ spec = describe "compiler" $ do
 
     it "always contains every rule in the output" $ do
       let c = (,)
-      let w = PluralWildcard mempty
+      let w = mempty
       let rule (x, _) = x
       let g xs = sort (toList $ rule <$> f xs w)
 
@@ -121,7 +117,7 @@ spec = describe "compiler" $ do
     it "copies the wildcard stream to new rules" $ do
       let xs = [Plaintext "foo"]
       let c = (,)
-      let w = PluralWildcard
+      let w = id
       let g ys = toList (f ys (w xs))
 
       g [] `shouldBe` (flip c xs <$> (universe :: [PluralRule]))
@@ -133,4 +129,4 @@ spec = describe "compiler" $ do
       let c x y = (x, [Plaintext y])
       let xs = [c Two "foo", c Many "", c Zero "bar", c One "baz", c Few ""]
 
-      f xs (PluralWildcard [Plaintext "any"]) `shouldBe` fromList xs
+      f xs [Plaintext "any"] `shouldBe` fromList xs

--- a/test/Intlc/CompilerSpec.hs
+++ b/test/Intlc/CompilerSpec.hs
@@ -43,8 +43,8 @@ spec = describe "compiler" $ do
       flatten (Message [Plaintext "xyz"]) `shouldBe` Message [Plaintext "xyz"]
 
     describe "flattens shallow select" $ do
-      let foo = SelectCase "foo" [Plaintext "a dog"]
-      let foof = SelectCase "foo" [Plaintext "I have a dog"]
+      let foo = ("foo", [Plaintext "a dog"])
+      let foof = ("foo", [Plaintext "I have a dog"])
 
       it "with a wildcard" $ do
         let other = SelectWildcard [Plaintext "many dogs"]
@@ -75,7 +75,7 @@ spec = describe "compiler" $ do
               [ Number "count"
               , Plaintext " dogs, the newest of which is "
               , Select "name" $ These
-                (pure $ SelectCase "hodor" [Plaintext "Hodor"])
+                (pure ("hodor", [Plaintext "Hodor"]))
                 (SelectWildcard [Plaintext "unknown"])
               ]
             , Plaintext "!"
@@ -85,12 +85,12 @@ spec = describe "compiler" $ do
               []
               (pure (One, [Plaintext "I have a dog!"]))
               [ Select "name" $ These
-                (pure $ SelectCase "hodor"
+                (pure ("hodor",
                   [ Plaintext "I have "
                   , Number "count"
                   , Plaintext " dogs, the newest of which is Hodor!"
                   ]
-                )
+                ))
                 (SelectWildcard
                   [ Plaintext "I have "
                   , Number "count"

--- a/test/Intlc/CompilerSpec.hs
+++ b/test/Intlc/CompilerSpec.hs
@@ -1,6 +1,5 @@
 module Intlc.CompilerSpec (spec) where
 
-import           Data.These        (These (..))
 import           Intlc.Compiler    (compileDataset, compileFlattened,
                                     expandRules, flatten)
 import           Intlc.Core        (Backend (..), Locale (Locale),
@@ -50,12 +49,12 @@ spec = describe "compiler" $ do
         let other = [Plaintext "many dogs"]
         let otherf = [Plaintext "I have many dogs"]
 
-        flatten (Message [Plaintext "I have ", Select "thing" $ These (pure foo) other]) `shouldBe`
-          Message (pure . Select "thing" $ These (pure foof) otherf)
+        flatten (Message [Plaintext "I have ", SelectNamedWild "thing" (pure foo) other]) `shouldBe`
+          Message (pure $ SelectNamedWild "thing" (pure foof) otherf)
 
       it "without a wildcard" $ do
-        flatten (Message [Plaintext "I have ", Select "thing" $ This (pure foo)]) `shouldBe`
-          Message (pure . Select "thing" $ This (pure foof))
+        flatten (Message [Plaintext "I have ", SelectNamed "thing" (pure foo)]) `shouldBe`
+          Message (pure $ SelectNamed "thing" (pure foof))
 
     it "flattens shallow plural" $ do
       let other = [Plaintext "many dogs"]
@@ -74,7 +73,7 @@ spec = describe "compiler" $ do
               (pure (One, [Plaintext "a dog"]))
               [ Number "count"
               , Plaintext " dogs, the newest of which is "
-              , Select "name" $ These
+              , SelectNamedWild "name"
                 (pure ("hodor", [Plaintext "Hodor"]))
                 [Plaintext "unknown"]
               ]
@@ -84,7 +83,7 @@ spec = describe "compiler" $ do
             CardinalInexact "count"
               []
               (pure (One, [Plaintext "I have a dog!"]))
-              [ Select "name" $ These
+              [ SelectNamedWild "name"
                 (pure ("hodor",
                   [ Plaintext "I have "
                   , Number "count"

--- a/test/Intlc/LinterSpec.hs
+++ b/test/Intlc/LinterSpec.hs
@@ -16,9 +16,9 @@ spec = describe "linter" $ do
       let lint = lintWith' redundantSelectRule
 
       it "succeeds on select with any non-wildcard case" $ do
-        lint (Message [Select "x" $ This (pure $ SelectCase "y" [])])
+        lint (Message [Select "x" $ This (pure ("y", []))])
           `shouldBe` Success
-        lint (Message [Select "x" $ These (pure $ SelectCase "y" []) (SelectWildcard [])])
+        lint (Message [Select "x" $ These (pure ("y", [])) (SelectWildcard [])])
           `shouldBe` Success
 
       it "fails on selects with only a wildcard" $ do

--- a/test/Intlc/LinterSpec.hs
+++ b/test/Intlc/LinterSpec.hs
@@ -18,11 +18,11 @@ spec = describe "linter" $ do
       it "succeeds on select with any non-wildcard case" $ do
         lint (Message [Select "x" $ This (pure ("y", []))])
           `shouldBe` Success
-        lint (Message [Select "x" $ These (pure ("y", [])) (SelectWildcard [])])
+        lint (Message [Select "x" $ These (pure ("y", [])) []])
           `shouldBe` Success
 
       it "fails on selects with only a wildcard" $ do
-        let s n = Select n . That . SelectWildcard
+        let s n = Select n . That
 
         lint (Message [s "x" [s "y" []], s "z" []])
           `shouldBe` Failure (pure $ RedundantSelect ("x" :| ["y", "z"]))
@@ -72,7 +72,7 @@ spec = describe "linter" $ do
     describe "interpolations" $ do
       let lint = lintWith' interpolationsRule
       -- An example interpolation that's affected by this lint rule.
-      let f n = Select n . That . SelectWildcard
+      let f n = Select n . That
 
       it "lints streams with 1 plain text node" $ do
         lint (Message [Plaintext "yay"]) `shouldBe` Success

--- a/test/Intlc/LinterSpec.hs
+++ b/test/Intlc/LinterSpec.hs
@@ -35,23 +35,23 @@ spec = describe "linter" $ do
           `shouldBe` Success
 
       it "succeeds on ordinal plural with any non-wildcard case" $ do
-        lint (Message [Ordinal "x" [(PluralExact "42", [])] [] (PluralWildcard [])])
+        lint (Message [Ordinal "x" [(PluralExact "42", [])] [] []])
           `shouldBe` Success
-        lint (Message [Ordinal "x" [] [(Two, [])] (PluralWildcard [])])
+        lint (Message [Ordinal "x" [] [(Two, [])] []])
           `shouldBe` Success
 
       it "succeeds on inexact cardinal plural with any non-wildcard case" $ do
-        lint (Message [CardinalInexact "x" [(PluralExact "42", [])] [] (PluralWildcard [])])
+        lint (Message [CardinalInexact "x" [(PluralExact "42", [])] [] []])
           `shouldBe` Success
-        lint (Message [CardinalInexact "x" [] [(Two, [])] (PluralWildcard [])])
+        lint (Message [CardinalInexact "x" [] [(Two, [])] []])
           `shouldBe` Success
 
       it "fails on ordinal plural with only a wildcard" $ do
-        lint (Message [Ordinal "x" [] [] (PluralWildcard [])])
+        lint (Message [Ordinal "x" [] [] []])
           `shouldBe` Failure (pure . RedundantPlural . pure $ "x")
 
       it "fails on inexact cardinal plural with only a wildcard" $ do
-        lint (Message [CardinalInexact "x" [] [] (PluralWildcard [])])
+        lint (Message [CardinalInexact "x" [] [] []])
           `shouldBe` Failure (pure . RedundantPlural . pure $ "x")
 
   describe "internal" $ do
@@ -93,7 +93,7 @@ spec = describe "linter" $ do
         let cb = flip Callback mempty
         lint (Message [cb "x", cb "y"]) `shouldBe` Success
 
-        let p n = Ordinal n [] (pure (Zero, [])) (PluralWildcard [])
+        let p n = Ordinal n [] (pure (Zero, [])) []
         lint (Message [p "x", p "y"]) `shouldBe` Success
 
       it "does not lint streams with 2 or more complex interpolations" $ do

--- a/test/Intlc/LinterSpec.hs
+++ b/test/Intlc/LinterSpec.hs
@@ -74,10 +74,10 @@ spec = describe "linter" $ do
       -- An example interpolation that's affected by this lint rule.
       let f n = Select n . That . SelectWildcard
 
-      it "lints streams with 1 plain text token" $ do
+      it "lints streams with 1 plain text node" $ do
         lint (Message [Plaintext "yay"]) `shouldBe` Success
 
-      it "lints streams with 2 or more plain text token" $ do
+      it "lints streams with 2 or more plain text node" $ do
         lint (Message [Plaintext "yay", Plaintext "Hello"]) `shouldBe` Success
 
       it "lints streams with 1 simple interpolation" $ do

--- a/test/Intlc/LinterSpec.hs
+++ b/test/Intlc/LinterSpec.hs
@@ -31,19 +31,19 @@ spec = describe "linter" $ do
       let lint = lintWith' redundantPluralRule
 
       it "succeeds on exact cardinal plural" $ do
-        lint (Message [CardinalExact "x" (pure $ PluralCase (PluralExact "42") [])])
+        lint (Message [CardinalExact "x" (pure (PluralExact "42", []))])
           `shouldBe` Success
 
       it "succeeds on ordinal plural with any non-wildcard case" $ do
-        lint (Message [Ordinal "x" [PluralCase (PluralExact "42") []] [] (PluralWildcard [])])
+        lint (Message [Ordinal "x" [(PluralExact "42", [])] [] (PluralWildcard [])])
           `shouldBe` Success
-        lint (Message [Ordinal "x" [] [PluralCase  Two []] (PluralWildcard [])])
+        lint (Message [Ordinal "x" [] [(Two, [])] (PluralWildcard [])])
           `shouldBe` Success
 
       it "succeeds on inexact cardinal plural with any non-wildcard case" $ do
-        lint (Message [CardinalInexact "x" [PluralCase (PluralExact "42") []] [] (PluralWildcard [])])
+        lint (Message [CardinalInexact "x" [(PluralExact "42", [])] [] (PluralWildcard [])])
           `shouldBe` Success
-        lint (Message [CardinalInexact "x" [] [PluralCase  Two []] (PluralWildcard [])])
+        lint (Message [CardinalInexact "x" [] [(Two, [])] (PluralWildcard [])])
           `shouldBe` Success
 
       it "fails on ordinal plural with only a wildcard" $ do
@@ -93,7 +93,7 @@ spec = describe "linter" $ do
         let cb = flip Callback mempty
         lint (Message [cb "x", cb "y"]) `shouldBe` Success
 
-        let p n = Ordinal n [] (pure $ PluralCase Zero []) (PluralWildcard [])
+        let p n = Ordinal n [] (pure (Zero, [])) (PluralWildcard [])
         lint (Message [p "x", p "y"]) `shouldBe` Success
 
       it "does not lint streams with 2 or more complex interpolations" $ do

--- a/test/Intlc/LinterSpec.hs
+++ b/test/Intlc/LinterSpec.hs
@@ -31,27 +31,27 @@ spec = describe "linter" $ do
       let lint = lintWith' redundantPluralRule
 
       it "succeeds on exact cardinal plural" $ do
-        lint (Message [Plural "x" $ CardinalExact (pure $ PluralCase (PluralExact "42") [])])
+        lint (Message [CardinalExact "x" (pure $ PluralCase (PluralExact "42") [])])
           `shouldBe` Success
 
       it "succeeds on ordinal plural with any non-wildcard case" $ do
-        lint (Message [Plural "x" $ Ordinal [PluralCase (PluralExact "42") []] [] (PluralWildcard [])])
+        lint (Message [Ordinal "x" [PluralCase (PluralExact "42") []] [] (PluralWildcard [])])
           `shouldBe` Success
-        lint (Message [Plural "x" $ Ordinal [] [PluralCase  Two []] (PluralWildcard [])])
+        lint (Message [Ordinal "x" [] [PluralCase  Two []] (PluralWildcard [])])
           `shouldBe` Success
 
       it "succeeds on inexact cardinal plural with any non-wildcard case" $ do
-        lint (Message [Plural "x" $ CardinalInexact [PluralCase (PluralExact "42") []] [] (PluralWildcard [])])
+        lint (Message [CardinalInexact "x" [PluralCase (PluralExact "42") []] [] (PluralWildcard [])])
           `shouldBe` Success
-        lint (Message [Plural "x" $ CardinalInexact [] [PluralCase  Two []] (PluralWildcard [])])
+        lint (Message [CardinalInexact "x" [] [PluralCase  Two []] (PluralWildcard [])])
           `shouldBe` Success
 
       it "fails on ordinal plural with only a wildcard" $ do
-        lint (Message [Plural "x" $ Ordinal [] [] (PluralWildcard [])])
+        lint (Message [Ordinal "x" [] [] (PluralWildcard [])])
           `shouldBe` Failure (pure . RedundantPlural . pure $ "x")
 
       it "fails on inexact cardinal plural with only a wildcard" $ do
-        lint (Message [Plural "x" $ CardinalInexact [] [] (PluralWildcard [])])
+        lint (Message [CardinalInexact "x" [] [] (PluralWildcard [])])
           `shouldBe` Failure (pure . RedundantPlural . pure $ "x")
 
   describe "internal" $ do
@@ -93,7 +93,7 @@ spec = describe "linter" $ do
         let cb = flip Callback mempty
         lint (Message [cb "x", cb "y"]) `shouldBe` Success
 
-        let p n = Plural n $ Ordinal [] (pure $ PluralCase Zero []) (PluralWildcard [])
+        let p n = Ordinal n [] (pure $ PluralCase Zero []) (PluralWildcard [])
         lint (Message [p "x", p "y"]) `shouldBe` Success
 
       it "does not lint streams with 2 or more complex interpolations" $ do

--- a/test/Intlc/LinterSpec.hs
+++ b/test/Intlc/LinterSpec.hs
@@ -1,6 +1,5 @@
 module Intlc.LinterSpec where
 
-import           Data.These   (These (..))
 import           Intlc.ICU
 import           Intlc.Linter
 import           Prelude
@@ -16,13 +15,13 @@ spec = describe "linter" $ do
       let lint = lintWith' redundantSelectRule
 
       it "succeeds on select with any non-wildcard case" $ do
-        lint (Message [Select "x" $ This (pure ("y", []))])
+        lint (Message [SelectNamed "x" (pure ("y", []))])
           `shouldBe` Success
-        lint (Message [Select "x" $ These (pure ("y", [])) []])
+        lint (Message [SelectNamedWild "x" (pure ("y", [])) []])
           `shouldBe` Success
 
       it "fails on selects with only a wildcard" $ do
-        let s n = Select n . That
+        let s = SelectWild
 
         lint (Message [s "x" [s "y" []], s "z" []])
           `shouldBe` Failure (pure $ RedundantSelect ("x" :| ["y", "z"]))
@@ -72,7 +71,7 @@ spec = describe "linter" $ do
     describe "interpolations" $ do
       let lint = lintWith' interpolationsRule
       -- An example interpolation that's affected by this lint rule.
-      let f n = Select n . That
+      let f = SelectWild
 
       it "lints streams with 1 plain text node" $ do
         lint (Message [Plaintext "yay"]) `shouldBe` Success

--- a/test/Intlc/Parser/ICUSpec.hs
+++ b/test/Intlc/Parser/ICUSpec.hs
@@ -196,13 +196,13 @@ spec = describe "ICU parser" $ do
     let selectCases' = selectCases <* eof
 
     it "disallows wildcard not at the end" $ do
-      parse selectCases' "foo {bar} other {baz}" `shouldParse` These (pure ("foo", [Plaintext "bar"])) (SelectWildcard [Plaintext "baz"])
+      parse selectCases' "foo {bar} other {baz}" `shouldParse` These (pure ("foo", [Plaintext "bar"])) [Plaintext "baz"]
       parse selectCases' `shouldFailOn` "other {bar} foo {baz}"
 
     it "tolerates empty cases" $ do
-      parse selectCases' "x {} other {}" `shouldParse` These (pure ("x", [])) (SelectWildcard [])
+      parse selectCases' "x {} other {}" `shouldParse` These (pure ("x", [])) []
 
     it "allows no non-wildcard case" $ do
       parse selectCases' "foo {bar}" `shouldParse` This (pure ("foo", [Plaintext "bar"]))
-      parse selectCases' "foo {bar} other {baz}" `shouldParse` These (pure ("foo", [Plaintext "bar"])) (SelectWildcard [Plaintext "baz"])
-      parse selectCases' "other {foo}" `shouldParse` That (SelectWildcard [Plaintext "foo"])
+      parse selectCases' "foo {bar} other {baz}" `shouldParse` These (pure ("foo", [Plaintext "bar"])) [Plaintext "baz"]
+      parse selectCases' "other {foo}" `shouldParse` That [Plaintext "foo"]

--- a/test/Intlc/Parser/ICUSpec.hs
+++ b/test/Intlc/Parser/ICUSpec.hs
@@ -43,25 +43,23 @@ spec = describe "ICU parser" $ do
         let n = pure $ PluralRef "n"
         parse msg "{n, plural, one {#} other {#}}" `shouldParse`
           (Message . pure $
-            CardinalInexact "n" [] (pure $ PluralCase One n) (PluralWildcard n))
+            CardinalInexact "n" [] (pure (One, n)) (PluralWildcard n))
 
       it "parses as nearest arg inside deep plural" $ do
         let n = pure $ PluralRef "n"
         let i = pure $ PluralRef "i"
         parse msg "{n, plural, one {{i, plural, one {#} other {#}}} other {#}}" `shouldParse`
           (Message . pure $
-            CardinalInexact "n" [] (pure $ PluralCase One (
+            CardinalInexact "n" [] (pure (One,
               pure $
-                CardinalInexact "i" [] (pure $ PluralCase One i) (PluralWildcard i)
-            )) (PluralWildcard n))
+                CardinalInexact "i" [] (pure (One, i)) (PluralWildcard i))) (PluralWildcard n))
 
       it "parses as arg nested inside other interpolation" $ do
         let n = pure $ PluralRef "n"
         parse msg "{n, plural, one {<f>#</f>} other {#}}" `shouldParse`
           (Message . pure $
-            CardinalInexact "n" [] (pure $ PluralCase One (
-              pure . Callback "f" $ n
-            )) (PluralWildcard n))
+            CardinalInexact "n" [] (pure (One,
+              pure . Callback "f" $ n)) (PluralWildcard n))
 
     describe "escaping" $ do
       it "escapes non-empty contents between single quotes" $ do
@@ -84,7 +82,7 @@ spec = describe "ICU parser" $ do
           Message [Plaintext "a ", String "b", Plaintext " 'c ", String "d", Plaintext " e"]
         parse msg "{n, plural, =42 {# '#}}" `shouldParse`
           let xs = [PluralRef "n", Plaintext " #"]
-           in Message [CardinalExact "n" (pure $ PluralCase (PluralExact "42") xs)]
+           in Message [CardinalExact "n" (pure (PluralExact "42", xs))]
 
       it "escapes two single quotes as one single quote" $ do
         parse msg "This '{isn''t}' obvious." `shouldParse` Message [Plaintext "This {isn't} obvious."]
@@ -171,7 +169,7 @@ spec = describe "ICU parser" $ do
 
     it "parses literal and plural cases, wildcard, and interpolation node" $ do
       parseWith (emptyState { pluralCtxName = Just "xyz" }) cardinalCases' "=0 {foo} few {bar} other {baz #}" `shouldParse`
-        CardinalInexact "arg" (pure $ PluralCase (PluralExact "0") [Plaintext "foo"]) (pure $ PluralCase Few [Plaintext "bar"]) (PluralWildcard [Plaintext "baz ", PluralRef "xyz"])
+        CardinalInexact "arg" (pure (PluralExact "0", [Plaintext "foo"])) (pure (Few, [Plaintext "bar"])) (PluralWildcard [Plaintext "baz ", PluralRef "xyz"])
 
   describe "selectordinal" $ do
     let ordinalCases' = ordinalCases "arg" <* eof
@@ -192,7 +190,7 @@ spec = describe "ICU parser" $ do
 
     it "parses literal and plural cases, wildcard, and interpolation node" $ do
       parseWith (emptyState { pluralCtxName = Just "xyz" }) ordinalCases' "=0 {foo} few {bar} other {baz #}" `shouldParse`
-        Ordinal "arg" (pure $ PluralCase (PluralExact "0") [Plaintext "foo"]) (pure $ PluralCase Few [Plaintext "bar"]) (PluralWildcard [Plaintext "baz ", PluralRef "xyz"])
+        Ordinal "arg" (pure (PluralExact "0", [Plaintext "foo"])) (pure (Few, [Plaintext "bar"])) (PluralWildcard [Plaintext "baz ", PluralRef "xyz"])
 
   describe "select" $ do
     let selectCases' = selectCases <* eof

--- a/test/Intlc/Parser/ICUSpec.hs
+++ b/test/Intlc/Parser/ICUSpec.hs
@@ -43,7 +43,7 @@ spec = describe "ICU parser" $ do
         let n = pure $ PluralRef "n"
         parse msg "{n, plural, one {#} other {#}}" `shouldParse`
           (Message . pure $
-            CardinalInexact "n" [] (pure (One, n)) (PluralWildcard n))
+            CardinalInexact "n" [] (pure (One, n)) n)
 
       it "parses as nearest arg inside deep plural" $ do
         let n = pure $ PluralRef "n"
@@ -52,14 +52,14 @@ spec = describe "ICU parser" $ do
           (Message . pure $
             CardinalInexact "n" [] (pure (One,
               pure $
-                CardinalInexact "i" [] (pure (One, i)) (PluralWildcard i))) (PluralWildcard n))
+                CardinalInexact "i" [] (pure (One, i)) i)) n)
 
       it "parses as arg nested inside other interpolation" $ do
         let n = pure $ PluralRef "n"
         parse msg "{n, plural, one {<f>#</f>} other {#}}" `shouldParse`
           (Message . pure $
             CardinalInexact "n" [] (pure (One,
-              pure . Callback "f" $ n)) (PluralWildcard n))
+              pure . Callback "f" $ n)) n)
 
     describe "escaping" $ do
       it "escapes non-empty contents between single quotes" $ do
@@ -169,7 +169,7 @@ spec = describe "ICU parser" $ do
 
     it "parses literal and plural cases, wildcard, and interpolation node" $ do
       parseWith (emptyState { pluralCtxName = Just "xyz" }) cardinalCases' "=0 {foo} few {bar} other {baz #}" `shouldParse`
-        CardinalInexact "arg" (pure (PluralExact "0", [Plaintext "foo"])) (pure (Few, [Plaintext "bar"])) (PluralWildcard [Plaintext "baz ", PluralRef "xyz"])
+        CardinalInexact "arg" (pure (PluralExact "0", [Plaintext "foo"])) (pure (Few, [Plaintext "bar"])) [Plaintext "baz ", PluralRef "xyz"]
 
   describe "selectordinal" $ do
     let ordinalCases' = ordinalCases "arg" <* eof
@@ -190,7 +190,7 @@ spec = describe "ICU parser" $ do
 
     it "parses literal and plural cases, wildcard, and interpolation node" $ do
       parseWith (emptyState { pluralCtxName = Just "xyz" }) ordinalCases' "=0 {foo} few {bar} other {baz #}" `shouldParse`
-        Ordinal "arg" (pure (PluralExact "0", [Plaintext "foo"])) (pure (Few, [Plaintext "bar"])) (PluralWildcard [Plaintext "baz ", PluralRef "xyz"])
+        Ordinal "arg" (pure (PluralExact "0", [Plaintext "foo"])) (pure (Few, [Plaintext "bar"])) [Plaintext "baz ", PluralRef "xyz"]
 
   describe "select" $ do
     let selectCases' = selectCases <* eof

--- a/test/Intlc/Parser/ICUSpec.hs
+++ b/test/Intlc/Parser/ICUSpec.hs
@@ -169,7 +169,7 @@ spec = describe "ICU parser" $ do
       parse cardinalCases' `shouldSucceedOn` "=0 {foo} one {bar} other {baz}"
       parse cardinalCases' `shouldSucceedOn` "=0 {foo} =1 {bar}"
 
-    it "parses literal and plural cases, wildcard, and interpolation token" $ do
+    it "parses literal and plural cases, wildcard, and interpolation node" $ do
       parseWith (emptyState { pluralCtxName = Just "xyz" }) cardinalCases' "=0 {foo} few {bar} other {baz #}" `shouldParse`
         CardinalInexact (pure $ PluralCase (PluralExact "0") [Plaintext "foo"]) (pure $ PluralCase Few [Plaintext "bar"]) (PluralWildcard [Plaintext "baz ", PluralRef "xyz"])
 
@@ -190,7 +190,7 @@ spec = describe "ICU parser" $ do
       parse ordinalCases' `shouldFailOn`    "=0 {foo} one {bar}"
       parse ordinalCases' `shouldSucceedOn` "=0 {foo} one {bar} other {baz}"
 
-    it "parses literal and plural cases, wildcard, and interpolation token" $ do
+    it "parses literal and plural cases, wildcard, and interpolation node" $ do
       parseWith (emptyState { pluralCtxName = Just "xyz" }) ordinalCases' "=0 {foo} few {bar} other {baz #}" `shouldParse`
         Ordinal (pure $ PluralCase (PluralExact "0") [Plaintext "foo"]) (pure $ PluralCase Few [Plaintext "bar"]) (PluralWildcard [Plaintext "baz ", PluralRef "xyz"])
 

--- a/test/Intlc/Parser/ICUSpec.hs
+++ b/test/Intlc/Parser/ICUSpec.hs
@@ -37,7 +37,7 @@ spec = describe "ICU parser" $ do
         parse msg "#" `shouldParse` Message [Plaintext "#"]
         parse msg "{x, select, y {#}}" `shouldParse`
           (Message . pure $
-            Select "x" (This . pure $ SelectCase "y" (pure $ Plaintext "#")))
+            Select "x" (This . pure $ ("y", pure $ Plaintext "#")))
 
       it "parses as arg inside shallow plural" $ do
         let n = pure $ PluralRef "n"
@@ -196,13 +196,13 @@ spec = describe "ICU parser" $ do
     let selectCases' = selectCases <* eof
 
     it "disallows wildcard not at the end" $ do
-      parse selectCases' "foo {bar} other {baz}" `shouldParse` These (pure $ SelectCase "foo" [Plaintext "bar"]) (SelectWildcard [Plaintext "baz"])
+      parse selectCases' "foo {bar} other {baz}" `shouldParse` These (pure ("foo", [Plaintext "bar"])) (SelectWildcard [Plaintext "baz"])
       parse selectCases' `shouldFailOn` "other {bar} foo {baz}"
 
     it "tolerates empty cases" $ do
-      parse selectCases' "x {} other {}" `shouldParse` These (pure $ SelectCase "x" []) (SelectWildcard [])
+      parse selectCases' "x {} other {}" `shouldParse` These (pure ("x", [])) (SelectWildcard [])
 
     it "allows no non-wildcard case" $ do
-      parse selectCases' "foo {bar}" `shouldParse` This (pure $ SelectCase "foo" [Plaintext "bar"])
-      parse selectCases' "foo {bar} other {baz}" `shouldParse` These (pure $ SelectCase "foo" [Plaintext "bar"]) (SelectWildcard [Plaintext "baz"])
+      parse selectCases' "foo {bar}" `shouldParse` This (pure ("foo", [Plaintext "bar"]))
+      parse selectCases' "foo {bar} other {baz}" `shouldParse` These (pure ("foo", [Plaintext "bar"])) (SelectWildcard [Plaintext "baz"])
       parse selectCases' "other {foo}" `shouldParse` That (SelectWildcard [Plaintext "foo"])


### PR DESCRIPTION
I'm experimenting with recursion schemes and more exotic and potentially better representations of the AST than recursive lists. Still, this changeset represents a subjective improvement regardless of whether or not that other stuff pans out. Rather than a series of mutually recursive sum types, the AST is now represented as a list of a single recursive sum type. This arguably improves both readability and writeability; no more "what is `This`?", and no more having to remember the names of the nested sum constructors.

The commits are large but each represent a very narrow change. Look at the `Intlc.ICU` module as a starting point for the AST change and then a quick look around elsewhere to see how it affects the codebase.