### PR TITLE
Conditionally add HLS to dev shell & GHC 9.0.2

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: haskell/actions/setup@v2
         id: setup-haskell
         with:
-          ghc-version: 8.10.7
+          ghc-version: 9.0.2
       - run: cabal freeze
       - uses: actions/cache@v3
         with:
@@ -30,7 +30,7 @@ jobs:
       - uses: haskell/actions/setup@v2
         id: setup-haskell
         with:
-          ghc-version: 8.10.7
+          ghc-version: 9.0.2
       - run: cabal freeze
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: haskell/actions/setup@v2
         id: setup-haskell
         with:
-          ghc-version: 8.10.7
+          ghc-version: 9.0.2
       - run: cabal freeze
       - uses: actions/cache@v3
         with:

--- a/README.md
+++ b/README.md
@@ -88,4 +88,4 @@ The description is optional and ignored by intlc. It can be used documentatively
 
 ## Contributing
 
-Check out `ARCHITECTURE.md`. Currently building against GHC 8.10.7.
+Check out `ARCHITECTURE.md`. Currently building against GHC 9.0.2.

--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1656928814,
-        "narHash": "sha256-RIFfgBuKz6Hp89yRr7+NR5tzIAbn52h8vT6vXkYjZoM=",
+        "lastModified": 1659877975,
+        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "7e2a3b3dfd9af950a856d66b0a7d01e3c18aa249",
+        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
         "type": "github"
       },
       "original": {
@@ -17,11 +17,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1658644204,
-        "narHash": "sha256-MWyfCH9K3eVTXJUxBi67OQSAh9jJAnvWklM6qm4j8w8=",
+        "lastModified": 1665613119,
+        "narHash": "sha256-VTutbv5YKeBGWou6ladtgfx11h6et+Wlkdyh4jPJ3p0=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "2f0c3be57c348f4cfd8820f2d189e29a685d9c41",
+        "rev": "e06bd4b64bbfda91d74f13cb5eca89485d47528f",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -8,7 +8,7 @@
     flake-utils.lib.eachDefaultSystem (system:
       let pkgs = nixpkgs.legacyPackages.${system};
       in {
-        devShell = pkgs.mkShell {
+        devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [
             git
 

--- a/flake.nix
+++ b/flake.nix
@@ -12,9 +12,11 @@
           buildInputs = with pkgs; [
             git
 
-            haskell.compiler.ghc8107
-            haskell.packages.ghc8107.cabal-install
-            haskell.packages.ghc8107.hspec-golden
+            # We use mainline Haskell packages rather than specifying a custom
+            # GHC version to ensure everything we want is cached in Hydra.
+            ghc
+            cabal-install
+            haskellPackages.hspec-golden
 
             # For typechecking golden output
             nodejs

--- a/flake.nix
+++ b/flake.nix
@@ -7,6 +7,14 @@
   outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
       let pkgs = nixpkgs.legacyPackages.${system};
+          # HLS in nixpkgs is marked as broken on aarch64-darwin via LLVM 7,
+          # see:
+          #   https://github.com/NixOS/nixpkgs/blob/a410420844fe1ad6415cf9586308fe7538cc7584/pkgs/development/compilers/llvm/7/compiler-rt/default.nix#L108
+          #
+          # See also in unsplash/intlc: #162, #167
+          hls = if system == flake-utils.lib.system.aarch64-darwin
+            then [ ]
+            else [ pkgs.haskell-language-server ];
       in {
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [
@@ -21,7 +29,7 @@
             # For typechecking golden output
             nodejs
             yarn
-          ];
+          ] ++ hls;
         };
       });
 }

--- a/intlc.cabal
+++ b/intlc.cabal
@@ -18,7 +18,7 @@ common common
   ghc-options:
     -Wall
   build-depends:
-      base                 ^>=4.14
+      base                 ^>=4.15
     , bytestring           ^>=0.11
     , containers           ^>=0.6
     , extra                ^>=1.7


### PR DESCRIPTION
Replaces #167. This PR _should_:

- Ensure that all platforms can get GHC, Cabal, etc without any building necessary i.e. binaries should already be cached and fetched from Hydra CI. I suspect we could still get away with changing the GHC version a bit more liberally but let's leave that for today.
- Add HLS to the dev shell, but not for M1 Macs specifically for which it's still marked as broken. For these users HLS can still be sourced from the likes of ghcup. (Please check that the HLS you have is compatible with GHC 9.0.2!)

The issue with GHC 9.x and ghcup referenced in #162 should now be resolved.