### PR TITLE
Embed list directly into AST type

### DIFF
--- a/intlc.cabal
+++ b/intlc.cabal
@@ -97,6 +97,7 @@ test-suite test-intlc
     Intlc.Backend.TypeScriptSpec
     Intlc.CompilerSpec
     Intlc.EndToEndSpec
+    Intlc.ICUSpec
     Intlc.LinterSpec
     Intlc.Parser.JSONSpec
     Intlc.Parser.ICUSpec

--- a/lib/Intlc/Backend/ICU/Compiler.hs
+++ b/lib/Intlc/Backend/ICU/Compiler.hs
@@ -9,7 +9,7 @@
 module Intlc.Backend.ICU.Compiler where
 
 import           Intlc.ICU
-import           Prelude   hiding (Type)
+import           Prelude
 
 compileMsg :: Message -> Text
 compileMsg (Message xs) = stream xs

--- a/lib/Intlc/Backend/ICU/Compiler.hs
+++ b/lib/Intlc/Backend/ICU/Compiler.hs
@@ -8,35 +8,34 @@
 
 module Intlc.Backend.ICU.Compiler where
 
+import qualified Data.Text as T
 import           Intlc.ICU
 import           Prelude
 
 compileMsg :: Message -> Text
-compileMsg (Message xs) = stream xs
-
-stream :: Foldable f => f Node -> Text
-stream = foldMap node
+compileMsg = node . unMessage
 
 node :: Node -> Text
-node (Plaintext x)   = x
-node x@(Bool {})     = "{" <> (unArg . name $ x) <> ", boolean, true {" <> stream (trueCase x)  <> "} false {" <> stream (falseCase x) <> "}}"
-node (String n)      = "{" <> unArg n <> "}"
-node (Number n)      = "{" <> unArg n <> ", number}"
-node (Date n fmt)    = "{" <> unArg n <> ", date, "          <> dateTimeFmt fmt  <> "}"
-node (Time n fmt)    = "{" <> unArg n <> ", time, "          <> dateTimeFmt fmt  <> "}"
-node (CardinalExact n xs)        = "{" <> unArg n <> ", plural, " <> cases <> "}"
+node Fin = mempty
+node (Char c x)     = T.singleton c <> node x
+node x@(Bool {})    = "{" <> (unArg . name $ x) <> ", boolean, true {" <> node (trueCase x)  <> "} false {" <> node (falseCase x) <> "}}" <> node (next x)
+node (String n x)   = "{" <> unArg n <> "}" <> node x
+node (Number n x)   = "{" <> unArg n <> ", number}" <> node x
+node (Date n fmt x) = "{" <> unArg n <> ", date, " <> dateTimeFmt fmt  <> "}" <> node x
+node (Time n fmt x) = "{" <> unArg n <> ", time, " <> dateTimeFmt fmt  <> "}" <> node x
+node (CardinalExact n xs y)        = "{" <> unArg n <> ", plural, " <> cases <> "}" <> node y
   where cases = unwords . toList . fmap exactPluralCase $ xs
-node (CardinalInexact n xs ys w) = "{" <> unArg n <> ", plural, " <> cases <> "}"
+node (CardinalInexact n xs ys w z) = "{" <> unArg n <> ", plural, " <> cases <> "}" <> node z
   where cases = unwords . mconcat $ [exactPluralCase <$> xs, rulePluralCase <$> ys, pure $ wildcard w]
-node (Ordinal n xs ys w)         = "{" <> unArg n <> ", selectordinal, " <> cases <> "}"
+node (Ordinal n xs ys w z)         = "{" <> unArg n <> ", selectordinal, " <> cases <> "}" <> node z
   where cases = unwords $ (exactPluralCase <$> xs) <> (rulePluralCase <$> ys) <> pure (wildcard w)
-node PluralRef {}    = "#"
-node (SelectNamed n xs)       = "{" <> unArg n <> ", select, " <> cases <> "}"
+node (PluralRef _ x)    = "#" <> node x
+node (SelectNamed n xs y)       = "{" <> unArg n <> ", select, " <> cases <> "}" <> node y
   where cases = unwords . fmap selectCase . toList $ xs
-node (SelectWild n w)         = "{" <> unArg n <> ", select, " <> wildcard w <> "}"
-node (SelectNamedWild n xs w) = "{" <> unArg n <> ", select, " <> cases <> "}"
+node (SelectWild n w x)         = "{" <> unArg n <> ", select, " <> wildcard w <> "}" <> node x
+node (SelectNamedWild n xs w y) = "{" <> unArg n <> ", select, " <> cases <> "}" <> node y
   where cases = unwords . (<> pure (wildcard w)) . fmap selectCase . toList $ xs
-node (Callback n xs) = "<" <> unArg n <> ">"                 <> stream xs        <> "</" <> unArg n <> ">"
+node (Callback n xs y) = "<" <> unArg n <> ">" <> node xs <> "</" <> unArg n <> ">" <> node y
 
 dateTimeFmt :: DateTimeFmt -> Text
 dateTimeFmt Short  = "short"
@@ -45,10 +44,10 @@ dateTimeFmt Long   = "long"
 dateTimeFmt Full   = "full"
 
 exactPluralCase :: PluralCase PluralExact -> Text
-exactPluralCase (PluralExact n, xs) = "=" <> n <> " {" <> stream xs <> "}"
+exactPluralCase (PluralExact n, x) = "=" <> n <> " {" <> node x <> "}"
 
 rulePluralCase :: PluralCase PluralRule -> Text
-rulePluralCase (r, xs) = pluralRule r <> " {" <> stream xs <> "}"
+rulePluralCase (r, x) = pluralRule r <> " {" <> node x <> "}"
 
 pluralRule :: PluralRule -> Text
 pluralRule Zero = "zero"
@@ -58,7 +57,7 @@ pluralRule Few  = "few"
 pluralRule Many = "many"
 
 selectCase :: SelectCase -> Text
-selectCase (n, xs) = n <> " {" <> stream xs <> "}"
+selectCase (n, x) = n <> " {" <> node x <> "}"
 
-wildcard :: Stream -> Text
-wildcard xs = "other {" <> stream xs <> "}"
+wildcard :: Node -> Text
+wildcard x = "other {" <> node x <> "}"

--- a/lib/Intlc/Backend/JavaScript/Compiler.hs
+++ b/lib/Intlc/Backend/JavaScript/Compiler.hs
@@ -8,7 +8,7 @@ import           Intlc.Core                        (Backend (..), Dataset,
                                                     Locale (Locale),
                                                     Translation (backend))
 import qualified Intlc.ICU                         as ICU
-import           Prelude                           hiding (Type, fromList)
+import           Prelude
 import           Utils                             (apply2, (<>^))
 
 type Compiler = Reader Cfg

--- a/lib/Intlc/Backend/JavaScript/Language.hs
+++ b/lib/Intlc/Backend/JavaScript/Language.hs
@@ -1,8 +1,10 @@
 module Intlc.Backend.JavaScript.Language where
 
+import qualified Data.Text  as T
 import           Intlc.Core (Locale)
 import qualified Intlc.ICU  as ICU
 import           Prelude
+import           Utils      ((<>^))
 
 type ASTCompiler = Reader Locale
 
@@ -44,64 +46,66 @@ newtype Wildcard = Wildcard [Expr]
   deriving (Show, Eq)
 
 fromKeyedMsg :: Text -> ICU.Message -> ASTCompiler Stmt
-fromKeyedMsg n (ICU.Message xs) = Stmt n <$> (fromNode `mapM` xs)
+fromKeyedMsg n (ICU.Message x) = Stmt n <$> fromNode x
 
-fromNode :: ICU.Node -> ASTCompiler Expr
-fromNode (ICU.Plaintext x)   = pure $ TPrint x
-fromNode x@ICU.Bool {}       = do
+fromNode :: ICU.Node -> ASTCompiler [Expr]
+fromNode ICU.Fin        = pure mempty
+fromNode (ICU.Char c x) = pure (pure (TPrint (T.singleton c))) <>^ fromNode x
+fromNode x@ICU.Bool {}  = do
       l <- fromBoolCase True (ICU.trueCase x)
       r <- fromBoolCase False (ICU.falseCase x)
-      pure . TMatch . Match (ICU.name x) LitCond . LitMatchRet $ l :| [r]
-fromNode (ICU.String n)      = pure $ TStr n
-fromNode (ICU.Number n)      = pure $ TNum n
-fromNode (ICU.Date n x)      = pure $ TDate n x
-fromNode (ICU.Time n x)      = pure $ TTime n x
-fromNode (ICU.CardinalExact n lcs)              = TMatch . Match n LitCond . LitMatchRet <$> (fromExactPluralCase `mapM` lcs)
-fromNode (ICU.CardinalInexact n lcs [] w)       = TMatch . Match n LitCond <$> ret
+      let start = TMatch . Match (ICU.name x) LitCond . LitMatchRet $ l :| [r]
+      pure (pure start) <>^ fromNode (ICU.next x)
+fromNode (ICU.String n x)      = pure (pure (TStr n)) <>^ fromNode x
+fromNode (ICU.Number n x)      = pure (pure (TNum n)) <>^ fromNode x
+fromNode (ICU.Date n x y)      = pure (pure (TDate n x)) <>^ fromNode y
+fromNode (ICU.Time n x y)      = pure (pure (TTime n x)) <>^ fromNode y
+fromNode (ICU.CardinalExact n lcs x)              = (pure . TMatch . Match n LitCond . LitMatchRet <$> (fromExactPluralCase `mapM` lcs)) <>^ fromNode x
+fromNode (ICU.CardinalInexact n lcs [] w x)       = (pure . TMatch . Match n LitCond <$> ret) <>^ fromNode x
     where ret = NonLitMatchRet <$> (fromExactPluralCase `mapM` lcs) <*> fromPluralWildcard w
-fromNode (ICU.CardinalInexact n [] rcs w)       = TMatch . Match n CardinalPluralRuleCond <$> ret
+fromNode (ICU.CardinalInexact n [] rcs w x)       = (pure . TMatch . Match n CardinalPluralRuleCond <$> ret) <>^ fromNode x
     where ret = NonLitMatchRet <$> (fromRulePluralCase `mapM` rcs) <*> fromPluralWildcard w
-fromNode (ICU.CardinalInexact n (lc:lcs) rcs w) = TMatch . Match n LitCond <$> litRet
+fromNode (ICU.CardinalInexact n (lc:lcs) rcs w x) = (pure . TMatch . Match n LitCond <$> litRet) <>^ fromNode x
     where litRet = RecMatchRet <$> (fromExactPluralCase `mapM` lcs') <*> (Match n CardinalPluralRuleCond <$> ruleRet)
           ruleRet = NonLitMatchRet <$> (fromRulePluralCase `mapM` rcs) <*> fromPluralWildcard w
           lcs' = lc :| lcs
-fromNode (ICU.Ordinal n [] rcs w)               = TMatch . Match n OrdinalPluralRuleCond <$> m
+fromNode (ICU.Ordinal n [] rcs w x)               = (pure . TMatch . Match n OrdinalPluralRuleCond <$> m) <>^ fromNode x
     where m = NonLitMatchRet <$> (fromRulePluralCase `mapM` rcs) <*> fromPluralWildcard w
-fromNode (ICU.Ordinal n (lc:lcs) rcs w)         = TMatch . Match n LitCond <$> m
+fromNode (ICU.Ordinal n (lc:lcs) rcs w x)         = (pure . TMatch . Match n LitCond <$> m) <>^ fromNode x
     where m = RecMatchRet <$> ((:|) <$> fromExactPluralCase lc <*> (fromExactPluralCase `mapM` lcs)) <*> im
           im = Match n OrdinalPluralRuleCond <$> (NonLitMatchRet <$> (fromRulePluralCase `mapM` rcs) <*> fromPluralWildcard w)
 
-fromNode (ICU.PluralRef n)   = pure $ TNum n
-fromNode (ICU.SelectNamed n cs)       = TMatch . Match n LitCond . LitMatchRet <$> ret
+fromNode (ICU.PluralRef n x)   = pure (pure (TNum n)) <>^ fromNode x
+fromNode (ICU.SelectNamed n cs x)       = (pure . TMatch . Match n LitCond . LitMatchRet <$> ret) <>^ fromNode x
   where ret = fromSelectCase `mapM` cs
-fromNode (ICU.SelectWild n w)         = TMatch . Match n LitCond <$> ret
+fromNode (ICU.SelectWild n w x)         = (pure . TMatch . Match n LitCond <$> ret) <>^ fromNode x
   where ret = NonLitMatchRet mempty <$> fromSelectWildcard w
-fromNode (ICU.SelectNamedWild n cs w) = TMatch . Match n LitCond <$> ret
+fromNode (ICU.SelectNamedWild n cs w x) = (pure . TMatch . Match n LitCond <$> ret) <>^ fromNode x
   where ret = NonLitMatchRet <$> (toList <$> fromSelectCase `mapM` cs) <*> fromSelectWildcard w
-fromNode (ICU.Callback n xs) = TApply n <$> (fromNode `mapM` xs)
+fromNode (ICU.Callback n x y) = (pure . TApply n <$> fromNode x) <>^ fromNode y
 
 fromExactPluralCase :: ICU.PluralCase ICU.PluralExact -> ASTCompiler Branch
-fromExactPluralCase (ICU.PluralExact n, xs) = Branch n <$> (fromNode `mapM` xs)
+fromExactPluralCase (ICU.PluralExact n, x) = Branch n <$> fromNode x
 
 fromRulePluralCase :: ICU.PluralCase ICU.PluralRule -> ASTCompiler Branch
-fromRulePluralCase (r, xs) = Branch (qts matcher) <$> (fromNode `mapM` xs)
+fromRulePluralCase (r, x) = Branch (qts matcher) <$> fromNode x
   where matcher = case r of
          ICU.Zero -> "zero"
          ICU.One  -> "one"
          ICU.Two  -> "two"
          ICU.Few  -> "few"
          ICU.Many -> "many"
-        qts x = "'" <> x <> "'"
+        qts y = "'" <> y <> "'"
 
-fromPluralWildcard :: ICU.Stream -> ASTCompiler Wildcard
-fromPluralWildcard xs = Wildcard <$> (fromNode `mapM` xs)
+fromPluralWildcard :: ICU.Node -> ASTCompiler Wildcard
+fromPluralWildcard x = Wildcard <$> fromNode x
 
 fromSelectCase :: ICU.SelectCase -> ASTCompiler Branch
-fromSelectCase (x, ys) = Branch ("'" <> x <> "'") <$> (fromNode `mapM` ys)
+fromSelectCase (x, y) = Branch ("'" <> x <> "'") <$> fromNode y
 
-fromSelectWildcard :: ICU.Stream -> ASTCompiler Wildcard
-fromSelectWildcard xs = Wildcard <$> (fromNode `mapM` xs)
+fromSelectWildcard :: ICU.Node -> ASTCompiler Wildcard
+fromSelectWildcard x = Wildcard <$> fromNode x
 
-fromBoolCase :: Bool -> ICU.Stream -> ASTCompiler Branch
-fromBoolCase b xs = Branch b' <$> (fromNode `mapM` xs)
+fromBoolCase :: Bool -> ICU.Node -> ASTCompiler Branch
+fromBoolCase b x = Branch b' <$> fromNode x
   where b' = if b then "true" else "false"

--- a/lib/Intlc/Backend/TypeScript/Compiler.hs
+++ b/lib/Intlc/Backend/TypeScript/Compiler.hs
@@ -21,10 +21,10 @@ compileNamedExport s l k v = JS.compileStmt o s l k v
         -- Prevents TypeScript from narrowing, which absent this causes some
         -- nested switch output to fail typechecking.
         matchLitCond x = x <> " as typeof " <> x
-        arg = if hasInterpolations then "x" else "()"
-        hasInterpolations = flip any (ICU.unMessage v) $ \case
-          ICU.Plaintext {} -> False
-          _                -> True
+        arg = if hasInterpolations (ICU.unMessage v) then "x" else "()"
+        hasInterpolations ICU.Fin        = False
+        hasInterpolations (ICU.Char _ n) = hasInterpolations n
+        hasInterpolations _              = True
 
 compileTypeof :: InterpStrat -> ICU.Message -> Text
 compileTypeof x = let o = fromStrat x in flip runReader o . typeof . fromMsg o

--- a/lib/Intlc/Backend/TypeScript/Compiler.hs
+++ b/lib/Intlc/Backend/TypeScript/Compiler.hs
@@ -11,7 +11,7 @@ import qualified Intlc.Backend.JavaScript.Compiler as JS
 import           Intlc.Backend.TypeScript.Language
 import           Intlc.Core
 import qualified Intlc.ICU                         as ICU
-import           Prelude                           hiding (Type)
+import           Prelude
 import           Utils                             ((<>^))
 
 compileNamedExport :: InterpStrat -> Locale -> Text -> ICU.Message -> Text

--- a/lib/Intlc/Compiler.hs
+++ b/lib/Intlc/Compiler.hs
@@ -35,43 +35,51 @@ compileTranslation l k (Translation v be _) = case be of
   TypeScript      -> TS.compileNamedExport TemplateLit l k v
   TypeScriptReact -> TS.compileNamedExport JSX         l k v
 
-type ICUBool = (ICU.Stream, ICU.Stream)
-
 compileFlattened :: Dataset Translation -> Text
 compileFlattened = JSON.compileDataset . mapMsgs flatten
 
 mapMsgs :: (ICU.Message -> ICU.Message) -> Dataset Translation -> Dataset Translation
 mapMsgs f = fmap $ \x -> x { message = f (message x) }
 
--- Map every `Node`, included those nested, in a `Stream`. Order is
--- unspecified. The children of a node, if any, will be traversed after the
--- provided function is applied.
-mapNodes :: (ICU.Node -> ICU.Node) -> ICU.Stream -> ICU.Stream
-mapNodes f = fmap $ f >>> \case
-  ICU.Bool n xs ys  -> ICU.Bool n (f <$> xs) (f <$> ys)
-  ICU.CardinalExact n xs        -> ICU.CardinalExact n (mapPluralCase (fmap f) <$> xs)
-  ICU.CardinalInexact n xs ys w -> ICU.CardinalInexact n (mapPluralCase (fmap f) <$> xs) (mapPluralCase (fmap f) <$> ys) (fmap f w)
-  ICU.Ordinal n xs ys w         -> ICU.Ordinal n (mapPluralCase (fmap f) <$> xs) (mapPluralCase (fmap f) <$> ys) (fmap f w)
-  ICU.SelectNamed n xs       -> ICU.SelectNamed n (mapSelectCase (fmap f) <$> xs)
-  ICU.SelectWild n w         -> ICU.SelectWild n (f <$> w)
-  ICU.SelectNamedWild n xs w -> ICU.SelectNamedWild n (mapSelectCase (fmap f) <$> xs) (f <$> w)
-  ICU.Callback n xs -> ICU.Callback n (f <$> xs)
-  x                 -> x
+-- Map every `Node`, included those nested. Order is unspecified. The children
+-- of a node, if any, will be traversed after the provided function is applied.
+mapNodes :: (ICU.Node -> ICU.Node) -> ICU.Node -> ICU.Node
+mapNodes f = f >>> \case
+  ICU.Fin -> ICU.Fin
+  ICU.Char c x -> ICU.Char c (rec x)
+  ICU.String n x -> ICU.String n (rec x)
+  ICU.Number n x -> ICU.Number n (rec x)
+  ICU.Date n x y -> ICU.Date n x (rec y)
+  ICU.Time n x y -> ICU.Time n x (rec y)
+  ICU.Bool n x y z -> ICU.Bool n (f x) (f y) (rec z)
+  ICU.CardinalExact n xs y        -> ICU.CardinalExact n (mapPluralCase f <$> xs) (rec y)
+  ICU.CardinalInexact n xs ys w z -> ICU.CardinalInexact n (mapPluralCase f <$> xs) (mapPluralCase f <$> ys) (f w) (rec z)
+  ICU.Ordinal n xs ys w z         -> ICU.Ordinal n (mapPluralCase f <$> xs) (mapPluralCase f <$> ys) (f w) (rec z)
+  ICU.PluralRef n x -> ICU.PluralRef n (rec x)
+  ICU.SelectNamed n xs y       -> ICU.SelectNamed n (mapSelectCase f <$> xs) (rec y)
+  ICU.SelectWild n w x         -> ICU.SelectWild n (f w) (rec x)
+  ICU.SelectNamedWild n xs w y -> ICU.SelectNamedWild n (mapSelectCase f <$> xs) (f w) (rec y)
+  ICU.Callback n x y -> ICU.Callback n (f x) (rec y)
+  where rec = mapNodes f
 
 flatten :: ICU.Message -> ICU.Message
-flatten = ICU.Message . go [] . ICU.unMessage
-  where go :: ICU.Stream -> ICU.Stream -> ICU.Stream
-        go prev []                        = prev
-        go prev (ICU.Bool n xs ys : next) = pure . uncurry (ICU.Bool n) $ mapBoolStreams   (around prev next) (xs, ys)
-        go prev (ICU.SelectNamed n xs : next)         = pure $ ICU.SelectNamed n (mapSelectCase (around prev next) <$> xs)
-        go prev (ICU.SelectWild n w : next)           = pure $ ICU.SelectWild n (around prev next w)
-        go prev (ICU.SelectNamedWild n xs w : next)   = pure $ ICU.SelectNamedWild n (mapSelectCase (around prev next) <$> xs) (around prev next w)
-        go prev (ICU.CardinalExact n xs : next)        = pure $ ICU.CardinalExact n (mapPluralCase (around prev next) <$> xs)
-        go prev (ICU.CardinalInexact n xs ys w : next) = pure $ ICU.CardinalInexact n (mapPluralCase (around prev next) <$> xs) (mapPluralCase (around prev next) <$> ys) (around prev next w)
-        go prev (ICU.Ordinal n xs ys w : next)         = pure $ ICU.Ordinal n (mapPluralCase (around prev next) <$> xs) (mapPluralCase (around prev next) <$> ys) (around prev next w)
-        go prev (curr : next)             = go (prev <> pure curr) next
-        around ls rs = go [] . ICU.mergePlaintext . surround ls rs
-        surround ls rs cs = ls <> cs <> rs
+flatten = ICU.Message . go mempty . ICU.unMessage
+  where go :: ICU.Node -> ICU.Node -> ICU.Node
+        go prev rest =
+          let (curr, mnext) = ICU.sever rest
+              next = fold mnext
+              rec mid = go ICU.Fin (prev <> mid <> next)
+           in case curr of
+            ICU.Fin -> prev
+            ICU.Bool n x y _ -> ICU.Bool n (rec x) (rec y) ICU.Fin
+            ICU.CardinalExact n xs _        -> ICU.CardinalExact n (mapPluralCase rec <$> xs) ICU.Fin
+            ICU.CardinalInexact n xs ys w _ -> ICU.CardinalInexact n (mapPluralCase rec <$> xs) (mapPluralCase rec <$> ys) (rec w) ICU.Fin
+            ICU.Ordinal n xs ys w _         -> ICU.Ordinal n (mapPluralCase rec <$> xs) (mapPluralCase rec <$> ys) (rec w) ICU.Fin
+            ICU.PluralRef n _ -> ICU.PluralRef n ICU.Fin
+            ICU.SelectNamed n xs _       -> ICU.SelectNamed n (mapSelectCase rec <$> xs) ICU.Fin
+            ICU.SelectWild n w _         -> ICU.SelectWild n (rec w) ICU.Fin
+            ICU.SelectNamedWild n xs w _ -> ICU.SelectNamedWild n (mapSelectCase rec <$> xs) (rec w) ICU.Fin
+            _ -> go (prev <> curr) next
 
 -- Expands any plural with a rule to contain every rule. This makes ICU plural
 -- syntax usable on platforms which don't support ICU; translators can reuse
@@ -80,15 +88,15 @@ flatten = ICU.Message . go [] . ICU.unMessage
 -- Added plural rules inherit the content of the wildcard. Output order of
 -- rules is unspecified.
 expandPlurals :: ICU.Message -> ICU.Message
-expandPlurals (ICU.Message xs) = ICU.Message . flip mapNodes xs $ \case
-  p@(ICU.CardinalExact _ _    )        -> p
-  ICU.CardinalInexact n exacts rules w ->
-    ICU.CardinalInexact n exacts (toList $ expandRules rules w) w
-  ICU.Ordinal n exacts rules w         ->
-    ICU.Ordinal n exacts (toList $ expandRules rules w) w
-  x -> x
+expandPlurals (ICU.Message x) = ICU.Message . flip mapNodes x $ \case
+  p@(ICU.CardinalExact {})               -> p
+  ICU.CardinalInexact n exacts rules w y ->
+    ICU.CardinalInexact n exacts (toList $ expandRules rules w) w y
+  ICU.Ordinal n exacts rules w y         ->
+    ICU.Ordinal n exacts (toList $ expandRules rules w) w y
+  y -> y
 
-expandRules :: (Functor f, Foldable f) => f (ICU.PluralCase ICU.PluralRule) -> ICU.Stream -> NonEmpty (ICU.PluralCase ICU.PluralRule)
+expandRules :: (Functor f, Foldable f) => f (ICU.PluralCase ICU.PluralRule) -> ICU.Node -> NonEmpty (ICU.PluralCase ICU.PluralRule)
 -- `fromList` is a cheap way to promise the compiler that we'll return a
 -- non-empty list. This is logically guaranteed by one of the inputs to
 -- `unionBy` being non-empty, namely `extraCases` - though given the complexity
@@ -100,11 +108,8 @@ expandRules ys w = fromList $ unionBy ((==) `on` caseRule) (toList ys) extraCase
         allRules = universe
         caseRule (x, _) = x
 
-mapBoolStreams :: (ICU.Stream -> ICU.Stream) -> ICUBool -> ICUBool
-mapBoolStreams f (xs, ys) = (f xs, f ys)
+mapSelectCase :: (ICU.Node -> ICU.Node) -> ICU.SelectCase -> ICU.SelectCase
+mapSelectCase = second
 
-mapSelectCase :: (ICU.Stream -> ICU.Stream) -> ICU.SelectCase -> ICU.SelectCase
-mapSelectCase f (x, ys) = (x, f ys)
-
-mapPluralCase :: (ICU.Stream -> ICU.Stream) -> ICU.PluralCase a -> ICU.PluralCase a
-mapPluralCase f (x, ys) = (x, f ys)
+mapPluralCase :: (ICU.Node -> ICU.Node) -> ICU.PluralCase a -> ICU.PluralCase a
+mapPluralCase = second

--- a/lib/Intlc/ICU.hs
+++ b/lib/Intlc/ICU.hs
@@ -3,7 +3,7 @@
 
 module Intlc.ICU where
 
-import           Prelude hiding (Type)
+import           Prelude
 
 newtype Message = Message Stream
   deriving (Show, Eq)

--- a/lib/Intlc/ICU.hs
+++ b/lib/Intlc/ICU.hs
@@ -1,17 +1,17 @@
 -- This module defines an AST for ICU messages. We do not necessarily behave
 -- identically to other implementations.
+{-# LANGUAGE PatternSynonyms #-}
 
 module Intlc.ICU where
 
+import qualified Data.Text as T
 import           Prelude
 
-newtype Message = Message Stream
+newtype Message = Message Node
   deriving (Show, Eq)
 
-unMessage :: Message -> Stream
+unMessage :: Message -> Node
 unMessage (Message xs) = xs
-
-type Stream = [Node]
 
 newtype Arg = Arg Text
   deriving (Show, Eq, Ord, IsString)
@@ -20,18 +20,21 @@ unArg :: Arg -> Text
 unArg (Arg x) = x
 
 -- | A `Node` is either an interpolation - some sort of identifier for input -
--- or mere plaintext. A collection of nodes make up any message. A non-empty
--- message without any interpolation will be a single `Plaintext` node.
+-- or mere plaintext. A collection of nodes make up any message. The entire AST
+-- is represented as a single recursive node with the trailing `Node` always
+-- representing the following sibling. Termination is represented by `Fin`,
+-- equivalent to a list's `Nil`.
 --
 -- On interpolations we diverge from icu4j by supporting a boolean type, and
 -- not necessarily requiring wildcard cases.
 data Node
-  = Plaintext Text
-  | Bool { name :: Arg, trueCase :: Stream, falseCase :: Stream }
-  | String Arg
-  | Number Arg
-  | Date Arg DateTimeFmt
-  | Time Arg DateTimeFmt
+  = Fin
+  | Char Char Node
+  | Bool { name :: Arg, trueCase :: Node, falseCase :: Node, next :: Node }
+  | String Arg Node
+  | Number Arg Node
+  | Date Arg DateTimeFmt Node
+  | Time Arg DateTimeFmt Node
   -- The only cardinal plurals which do not require a wildcard are those
   -- consisting solely of literal/exact cases. This is because within the AST we
   -- only care about correctness and prospective type safety, not optimal use of
@@ -40,17 +43,51 @@ data Node
   -- Ordinal plurals always require a wildcard as per their intended usage with
   -- rules, however as with the cardinal plural type we'll allow a wider set of
   -- suboptimal usages that we can then lint against.
-  | CardinalExact Arg (NonEmpty (PluralCase PluralExact))
-  | CardinalInexact Arg [PluralCase PluralExact] [PluralCase PluralRule] Stream
-  | Ordinal Arg [PluralCase PluralExact] [PluralCase PluralRule] Stream
+  | CardinalExact Arg (NonEmpty (PluralCase PluralExact)) Node
+  | CardinalInexact Arg [PluralCase PluralExact] [PluralCase PluralRule] Node Node
+  | Ordinal Arg [PluralCase PluralExact] [PluralCase PluralRule] Node Node
   -- Plural hash references have their own distinct type rather than merely
   -- taking on `Number` to allow compilers to infer appropriately.
-  | PluralRef Arg
-  | SelectNamed Arg (NonEmpty SelectCase)
-  | SelectWild Arg Stream
-  | SelectNamedWild Arg (NonEmpty SelectCase) Stream
-  | Callback Arg Stream
+  | PluralRef Arg Node
+  | SelectNamed Arg (NonEmpty SelectCase) Node
+  | SelectWild Arg Node Node
+  | SelectNamedWild Arg (NonEmpty SelectCase) Node Node
+  | Callback Arg Node Node
   deriving (Show, Eq)
+
+-- Concatenating two `Nodes` places the second at the tail of the first:
+--   Char 'a' Fin <> Char 'b' (Char 'c' Fin) = Char 'a' (Char 'b' (Char 'c' Fin))
+--
+-- This is equivalent to what concatenation would look like if the sibling
+-- parameter in `Node`'s constructors were removed and replaced with a list.
+instance Semigroup Node where
+  l <> r = case l of
+    Fin                          -> r
+    Char c l'                    -> Char c (l' <> r)
+    Bool n t f l'                -> Bool n t f (l' <> r)
+    String n l'                  -> String n (l' <> r)
+    Number n l'                  -> Number n (l' <> r)
+    Date n f l'                  -> Date n f (l' <> r)
+    Time n f l'                  -> Time n f (l' <> r)
+    CardinalExact n pe l'        -> CardinalExact n pe (l' <> r)
+    CardinalInexact n pe pr w l' -> CardinalInexact n pe pr w (l' <> r)
+    Ordinal n pe pr w l'         -> Ordinal n pe pr w (l' <> r)
+    PluralRef n l'               -> PluralRef n (l' <> r)
+    SelectNamed n c l'           -> SelectNamed n c (l' <> r)
+    SelectWild n w l'            -> SelectWild n w (l' <> r)
+    SelectNamedWild n c w l'     -> SelectNamedWild n c w (l' <> r)
+    Callback n c l'              -> Callback n c (l' <> r)
+
+instance Monoid Node where
+  mempty = Fin
+
+-- "abc" = Char 'a' (Char 'b' (Char 'c' Fin))
+instance IsString Node where
+  fromString = foldr Char Fin
+
+-- | Consider utilising -XOverloadedStrings instead.
+fromText :: Text -> Node
+fromText = fromString . T.unpack
 
 data DateTimeFmt
   = Short
@@ -59,7 +96,7 @@ data DateTimeFmt
   | Full
   deriving (Show, Eq)
 
-type PluralCase a = (a, Stream)
+type PluralCase a = (a, Node)
 
 -- `Text` here is our count. It's represented as a string so that we can dump
 -- it back out without thinking about converting numeric types across
@@ -76,40 +113,119 @@ data PluralRule
   | Many
   deriving (Show, Eq, Ord, Enum, Bounded)
 
-type SelectCase = (Text, Stream)
+type SelectCase = (Text, Node)
 
--- | Merges any sibling `Plaintext` nodes in a `Stream`.
-mergePlaintext :: Stream -> Stream
-mergePlaintext []                               = []
-mergePlaintext (Plaintext x : Plaintext y : zs) = mergePlaintext $ Plaintext (x <> y) : zs
-mergePlaintext (x:ys)                           = x : mergePlaintext ys
+getInterpolationChildren :: Node -> Maybe Node
+getInterpolationChildren = fmap snd . getInterpolation
 
-getStream :: Node -> Maybe Stream
-getStream = fmap snd . getNamedStream
-
-getNamedStream :: Node -> Maybe (Arg, Stream)
-getNamedStream Plaintext {}    = Nothing
-getNamedStream String {}       = Nothing
-getNamedStream Number {}       = Nothing
-getNamedStream Date {}         = Nothing
-getNamedStream Time {}         = Nothing
-getNamedStream PluralRef {}    = Nothing
-getNamedStream x@(Bool {})     = Just (name x, trueCase x <> falseCase x)
-getNamedStream (CardinalExact n ls)        = Just (n, getPluralCaseStream `concatMap` ls)
-getNamedStream (CardinalInexact n ls rs w) = Just . (n,) $ mconcat
-  [ getPluralCaseStream `concatMap` ls
-  , getPluralCaseStream `concatMap` rs
+-- Returns a tuple of an interpolation's argument name and its concatenated
+-- children.
+getInterpolation :: Node -> Maybe (Arg, Node)
+getInterpolation Fin {}          = Nothing
+getInterpolation Char {}         = Nothing
+getInterpolation String {}       = Nothing
+getInterpolation Number {}       = Nothing
+getInterpolation Date {}         = Nothing
+getInterpolation Time {}         = Nothing
+getInterpolation PluralRef {}    = Nothing
+getInterpolation x@(Bool {})     = Just (name x, trueCase x <> falseCase x)
+getInterpolation (CardinalExact n ls _)        = Just (n, getPluralCaseNode `foldMap` ls)
+getInterpolation (CardinalInexact n ls rs w _) = Just . (n,) $ mconcat
+  [ getPluralCaseNode `foldMap` ls
+  , getPluralCaseNode `foldMap` rs
   , w
   ]
-getNamedStream (Ordinal n xs ys w)         = Just . (n,) $ mconcat
-  [ getPluralCaseStream `concatMap` xs
-  , getPluralCaseStream `concatMap` ys
+getInterpolation (Ordinal n xs ys w _)         = Just . (n,) $ mconcat
+  [ getPluralCaseNode `foldMap` xs
+  , getPluralCaseNode `foldMap` ys
   , w
   ]
-getNamedStream (SelectNamed n xs)        = Just (n, snd `concatMap` xs)
-getNamedStream (SelectWild n xs)         = Just (n, xs)
-getNamedStream (SelectNamedWild n xs ys) = Just (n, snd `concatMap` xs <> ys)
-getNamedStream (Callback n xs) = Just (n, xs)
+getInterpolation (SelectNamed n xs _)        = Just (n, snd `foldMap` xs)
+getInterpolation (SelectWild n xs _)         = Just (n, xs)
+getInterpolation (SelectNamedWild n xs ys _) = Just (n, snd `foldMap` xs <> ys)
+getInterpolation (Callback n xs _) = Just (n, xs)
 
-getPluralCaseStream :: PluralCase a -> Stream
-getPluralCaseStream = snd
+getNext :: Node -> Maybe Node
+getNext Fin                         = Nothing
+getNext (Char _ x)                  = Just x
+getNext (String _ x)                = Just x
+getNext (Number _ x)                = Just x
+getNext (Date _ _ x)                = Just x
+getNext (Time _ _ x)                = Just x
+getNext (PluralRef _ x)             = Just x
+getNext (Bool _ _ _ x)              = Just x
+getNext (CardinalExact _ _ x)       = Just x
+getNext (CardinalInexact _ _ _ _ x) = Just x
+getNext (Ordinal _ _ _ _ x)         = Just x
+getNext (SelectNamed _ _ x)         = Just x
+getNext (SelectWild _ _ x)          = Just x
+getNext (SelectNamedWild _ _ _ x)   = Just x
+getNext (Callback _ _ x)            = Just x
+
+getPluralCaseNode :: PluralCase a -> Node
+getPluralCaseNode = snd
+
+-- Pulls out the next node and replaces it, if any, with `Fin`.
+sever :: Node -> (Node, Maybe Node)
+sever = sansNext &&& getNext
+  where sansNext = \case
+          Fin                         -> Fin
+          Char c _                    -> Char c Fin
+          String n _                  -> String n Fin
+          Number n _                  -> Number n Fin
+          Date n f _                  -> Date n f Fin
+          Time n f _                  -> Time n f Fin
+          PluralRef n _               -> PluralRef n Fin
+          Bool n t f _                -> Bool n t f Fin
+          CardinalExact n pe _        -> CardinalExact n pe Fin
+          CardinalInexact n pe pr w _ -> CardinalInexact n pe pr w Fin
+          Ordinal n pe pr w _         -> Ordinal n pe pr w Fin
+          SelectNamed n c _           -> SelectNamed n c Fin
+          SelectWild n w _            -> SelectWild n w Fin
+          SelectNamedWild n c w _     -> SelectNamedWild n c w Fin
+          Callback n c _              -> Callback n c Fin
+
+-- A series of `Node` constructor aliases which partially apply the sibling as
+-- `Fin`. Particularly useful when writing out a large `Node` by hand, for
+-- example in tests.
+pattern Char' :: Char -> Node
+pattern Char' c = Char c Fin
+
+pattern String' :: Arg -> Node
+pattern String' n = String n Fin
+
+pattern Number' :: Arg -> Node
+pattern Number' n = Number n Fin
+
+pattern Date' :: Arg -> DateTimeFmt -> Node
+pattern Date' n f = Date n f Fin
+
+pattern Time' :: Arg -> DateTimeFmt -> Node
+pattern Time' n f = Time n f Fin
+
+pattern Bool' :: Arg -> Node -> Node -> Node
+pattern Bool' n t f = Bool n t f Fin
+
+pattern CardinalExact' :: Arg -> NonEmpty (PluralCase PluralExact) -> Node
+pattern CardinalExact' n pe = CardinalExact n pe Fin
+
+pattern CardinalInexact' :: Arg -> [PluralCase PluralExact] -> [PluralCase PluralRule] -> Node -> Node
+pattern CardinalInexact' n pe pr w = CardinalInexact n pe pr w Fin
+
+pattern Ordinal' :: Arg -> [PluralCase PluralExact] -> [PluralCase PluralRule] -> Node -> Node
+pattern Ordinal' n pe pr w = Ordinal n pe pr w Fin
+
+pattern PluralRef' :: Arg -> Node
+pattern PluralRef' n = PluralRef n Fin
+
+pattern SelectNamed' :: Arg -> NonEmpty SelectCase -> Node
+pattern SelectNamed' n c = SelectNamed n c Fin
+
+pattern SelectWild' :: Arg -> Node -> Node
+pattern SelectWild' n w = SelectWild n w Fin
+
+pattern SelectNamedWild' :: Arg -> NonEmpty SelectCase -> Node -> Node
+pattern SelectNamedWild' n c w = SelectNamedWild n c w Fin
+
+pattern Callback' :: Arg -> Node -> Node
+pattern Callback' n w = Callback n w Fin

--- a/lib/Intlc/Parser/ICU.hs
+++ b/lib/Intlc/Parser/ICU.hs
@@ -11,7 +11,7 @@ import           Intlc.ICU
 import           Intlc.Parser.Error                       (MessageParseErr (..),
                                                            ParseErr (FailedMsgParse),
                                                            failingWith)
-import           Prelude                                  hiding (Type)
+import           Prelude
 import           Text.Megaparsec                          hiding (State, Stream,
                                                            many, some)
 import           Text.Megaparsec.Char

--- a/lib/Intlc/Parser/ICU.hs
+++ b/lib/Intlc/Parser/ICU.hs
@@ -47,11 +47,11 @@ msg = msgTill =<< asks endOfInput
 
 -- Parse a message until the provided parser matches.
 msgTill :: Parser a -> Parser Message
-msgTill = fmap (Message . mergePlaintext) . streamTill
+msgTill = fmap Message . streamTill
 
 -- Parse a stream until the provided parser matches.
-streamTill :: Parser a -> Parser Stream
-streamTill = manyTill node
+streamTill :: Parser a -> Parser Node
+streamTill = fmap mconcat <$> manyTill node
 
 -- The core parser of this module. Parse as many of these as you'd like until
 -- reaching an anticipated delimiter, such as a double quote in the surrounding
@@ -64,31 +64,31 @@ node = choice
   -- `#`. When there's no such context, fail the parse in effect treating it
   -- as plaintext.
   , asks pluralCtxName >>= \case
-      Just n  -> PluralRef n <$ string "#"
+      Just n  -> PluralRef n Fin <$ string "#"
       Nothing -> empty
-  , Plaintext <$> plaintext
+  , plaintext
   ]
 
 -- Parse plaintext, including single quote escape sequences.
-plaintext :: Parser Text
+plaintext :: Parser Node
 plaintext = choice
   [ try escaped
-  , T.singleton <$> L.charLiteral
+  , flip Char Fin <$> L.charLiteral
   ]
 
 -- Follows ICU 4.8+ spec, see:
 --   https://unicode-org.github.io/icu/userguide/format_parse/messages/#quotingescaping
-escaped :: Parser Text
+escaped :: Parser Node
 escaped = apos *> choice
   -- Double escape two apostrophes as one, regardless of surrounding
   -- syntax: "''" -> "'"
-  [ "'" <$ apos
+  [ flip Char Fin <$> apos
   -- Escape everything until another apostrophe, being careful of internal
   -- double escapes: "'{a''}'" -> "{a'}". Must ensure it doesn't surpass the
   -- bounds of the surrounding parser as per `endOfInput`.
   , try $ do
       eom <- asks endOfInput
-      head' <- T.singleton <$> synOpen
+      head' <- flip Char Fin <$> synOpen
       -- Try and parse until end of input or a lone apostrophe. If end of input
       -- comes first then fail the parse.
       (tail', wasEom) <- someTill_ plaintext $ choice
@@ -96,9 +96,9 @@ escaped = apos *> choice
         , try $ False <$ apos <* notFollowedBy apos
         ]
       guard (not wasEom)
-      pure $ head' <> T.concat tail'
+      pure $ head' <> mconcat tail'
   -- Escape the next syntax character as plaintext: "'{" -> "{"
-  , T.singleton <$> synAll
+  , flip Char Fin <$> synAll
   ]
   where apos = char '\''
         synAll = synLone <|> synOpen <|> synClose
@@ -119,19 +119,19 @@ callback = do
     where children n = do
             eom <- asks endOfInput
             stream <- streamTill (lookAhead $ void (string "</") <|> eom)
-            pure . Callback n . mergePlaintext $ stream
+            pure . flip (Callback n) Fin $ stream
           closing = fmap isJust . hidden . optional . char $ '/'
 
 interp :: Parser Node
 interp = between (char '{') (char '}') $ do
   n <- arg
-  option (String n) (sep *> body n)
+  option (String n Fin) (sep *> body n)
   where sep = string "," <* hspace1
         body n = choice
-          [ uncurry (Bool n) <$> (string "boolean" *> sep *> boolCases)
-          , Number n <$ string "number"
-          , Date n <$> (string "date" *> sep *> dateTimeFmt)
-          , Time n <$> (string "time" *> sep *> dateTimeFmt)
+          [ (\(t, f) -> Bool n t f Fin) <$> (string "boolean" *> sep *> boolCases)
+          , Number n Fin <$ string "number"
+          , flip (Date n) Fin <$> (string "date" *> sep *> dateTimeFmt)
+          , flip (Time n) Fin <$> (string "time" *> sep *> dateTimeFmt)
           , withPluralCtx n $ choice
               [ string "plural"        *> sep *> cardinalCases n
               , string "selectordinal" *> sep *> ordinalCases n
@@ -148,10 +148,10 @@ dateTimeFmt = choice
   , Full   <$ string "full"
   ]
 
-caseBody :: Parser Stream
-caseBody = mergePlaintext <$> (string "{" *> streamTill (string "}"))
+caseBody :: Parser Node
+caseBody = string "{" *> streamTill (string "}")
 
-boolCases :: Parser (Stream, Stream)
+boolCases :: Parser (Node, Node)
 boolCases = (,)
   <$> (string "true"  *> hspace1 *> caseBody)
    <* hspace1
@@ -160,12 +160,12 @@ boolCases = (,)
 selectCases :: Arg -> Parser Node
 selectCases n = choice
   [ reconcile <$> cases <*> optional wildcard
-  , SelectWild n <$> wildcard
+  , flip (SelectWild n) Fin <$> wildcard
   ]
   where cases = NE.sepEndBy1 ((,) <$> (name <* hspace1) <*> caseBody) hspace1
         wildcard = string wildcardName *> hspace1 *> caseBody
-        reconcile cs (Just w) = SelectNamedWild n cs w
-        reconcile cs Nothing  = SelectNamed n cs
+        reconcile cs (Just w) = SelectNamedWild n cs w Fin
+        reconcile cs Nothing  = SelectNamed n cs Fin
         name = try $ mfilter (/= wildcardName) ident
         wildcardName = "other"
 
@@ -173,13 +173,15 @@ cardinalCases :: Arg -> Parser Node
 cardinalCases n = try (cardinalInexactCases n) <|> cardinalExactCases n
 
 cardinalExactCases :: Arg -> Parser Node
-cardinalExactCases n = CardinalExact n <$> NE.sepEndBy1 pluralExactCase hspace1
+cardinalExactCases n = flip (CardinalExact n) Fin <$> NE.sepEndBy1 pluralExactCase hspace1
 
 cardinalInexactCases :: Arg -> Parser Node
-cardinalInexactCases n = uncurry (CardinalInexact n) <$> mixedPluralCases <*> pluralWildcard
+cardinalInexactCases n = uncurry f <$> mixedPluralCases <*> pluralWildcard
+  where f e r w = CardinalInexact n e r w Fin
 
 ordinalCases :: Arg -> Parser Node
-ordinalCases n = uncurry (Ordinal n) <$> mixedPluralCases <*> pluralWildcard
+ordinalCases n = uncurry f <$> mixedPluralCases <*> pluralWildcard
+  where f e r w = Ordinal n e r w Fin
 
 mixedPluralCases :: Parser ([PluralCase PluralExact], [PluralCase PluralRule])
 mixedPluralCases = partitionEithers <$> sepEndBy (eitherP pluralExactCase pluralRuleCase) hspace1
@@ -200,5 +202,5 @@ pluralRule = choice
   , Many <$ string "many"
   ]
 
-pluralWildcard :: Parser Stream
+pluralWildcard :: Parser Node
 pluralWildcard = string "other" *> hspace1 *> caseBody

--- a/test/Intlc/CompilerSpec.hs
+++ b/test/Intlc/CompilerSpec.hs
@@ -12,7 +12,7 @@ import           Text.RawString.QQ (r)
 spec :: Spec
 spec = describe "compiler" $ do
   describe "compile" $ do
-    let f = compileDataset (Locale "any") . fromList . fmap (, Translation (Message [Plaintext "any"]) TypeScript Nothing)
+    let f = compileDataset (Locale "any") . fromList . fmap (, Translation (Message "any") TypeScript Nothing)
 
     it "validates keys don't contain invalid chars" $ do
       f ["goodKey"] `shouldSatisfy` isRight
@@ -27,74 +27,74 @@ spec = describe "compiler" $ do
   describe "compile flattened dataset" $ do
     it "flattens messages and outputs JSON" $ do
       compileFlattened (fromList
-        [ ("x", Translation (Message [Plaintext "xfoo"]) TypeScript Nothing)
-        , ("z", Translation (Message [Plaintext "zfoo"]) TypeScriptReact (Just "zbar"))
-        , ("y", Translation (Message [Plaintext "yfoo ", String "ybar"]) TypeScript Nothing)
+        [ ("x", Translation (Message "xfoo") TypeScript Nothing)
+        , ("z", Translation (Message "zfoo") TypeScriptReact (Just "zbar"))
+        , ("y", Translation (Message $ mconcat ["yfoo ", String' "ybar"]) TypeScript Nothing)
         ])
           `shouldBe` [r|{"x":{"message":"xfoo","backend":"ts","description":null},"y":{"message":"yfoo {ybar}","backend":"ts","description":null},"z":{"message":"zfoo","backend":"tsx","description":"zbar"}}|]
 
     it "escapes double quotes in JSON" $ do
-      compileFlattened (fromList [("x\"y", Translation (Message [Plaintext "\"z\""]) TypeScript Nothing)])
+      compileFlattened (fromList [("x\"y", Translation (Message "\"z\"") TypeScript Nothing)])
         `shouldBe` [r|{"x\"y":{"message":"\"z\"","backend":"ts","description":null}}|]
 
   describe "flatten message" $ do
     it "no-ops static" $ do
-      flatten (Message [Plaintext "xyz"]) `shouldBe` Message [Plaintext "xyz"]
+      flatten (Message "xyz") `shouldBe` Message "xyz"
 
     describe "flattens shallow select" $ do
-      let foo = ("foo", [Plaintext "a dog"])
-      let foof = ("foo", [Plaintext "I have a dog"])
+      let foo = ("foo", "a dog")
+      let foof = ("foo", "I have a dog")
 
       it "with a wildcard" $ do
-        let other = [Plaintext "many dogs"]
-        let otherf = [Plaintext "I have many dogs"]
+        let other = "many dogs"
+        let otherf = "I have many dogs"
 
-        flatten (Message [Plaintext "I have ", SelectNamedWild "thing" (pure foo) other]) `shouldBe`
-          Message (pure $ SelectNamedWild "thing" (pure foof) otherf)
+        flatten (Message $ mconcat ["I have ", SelectNamedWild' "thing" (pure foo) other]) `shouldBe`
+          Message (SelectNamedWild' "thing" (pure foof) otherf)
 
       it "without a wildcard" $ do
-        flatten (Message [Plaintext "I have ", SelectNamed "thing" (pure foo)]) `shouldBe`
-          Message (pure $ SelectNamed "thing" (pure foof))
+        flatten (Message $ mconcat ["I have ", SelectNamed' "thing" (pure foo)]) `shouldBe`
+          Message (SelectNamed' "thing" (pure foof))
 
     it "flattens shallow plural" $ do
-      let other = [Plaintext "many dogs"]
-      let otherf = [Plaintext "I have many dogs"]
-      let one = (One, [Plaintext "a dog"])
-      let onef = (One, [Plaintext "I have a dog"])
+      let other = "many dogs"
+      let otherf = "I have many dogs"
+      let one = (One, "a dog")
+      let onef = (One, "I have a dog")
 
-      flatten (Message [Plaintext "I have ", CardinalInexact "count" [] (pure one) other]) `shouldBe`
-        Message (pure $ CardinalInexact "count" [] (pure onef) otherf)
+      flatten (Message $ mconcat ["I have ", CardinalInexact' "count" [] (pure one) other]) `shouldBe`
+        Message (CardinalInexact' "count" [] (pure onef) otherf)
 
     it "flattens deep interpolations" $ do
-      let x = Message
-            [ Plaintext "I have "
-            , CardinalInexact "count"
+      let x = Message $ mconcat
+            [ "I have "
+            , CardinalInexact' "count"
               []
-              (pure (One, [Plaintext "a dog"]))
-              [ Number "count"
-              , Plaintext " dogs, the newest of which is "
-              , SelectNamedWild "name"
-                (pure ("hodor", [Plaintext "Hodor"]))
-                [Plaintext "unknown"]
-              ]
-            , Plaintext "!"
+              (pure (One, "a dog"))
+              (mconcat [ Number' "count"
+              , " dogs, the newest of which is "
+              , SelectNamedWild' "name"
+                (pure ("hodor", "Hodor"))
+                "unknown"
+              ])
+            , "!"
             ]
-      let y = Message . pure $
-            CardinalInexact "count"
+      let y = Message $
+            CardinalInexact' "count"
               []
-              (pure (One, [Plaintext "I have a dog!"]))
-              [ SelectNamedWild "name"
+              (pure (One, "I have a dog!"))
+              (mconcat [ SelectNamedWild' "name"
                 (pure ("hodor",
-                  [ Plaintext "I have "
-                  , Number "count"
-                  , Plaintext " dogs, the newest of which is Hodor!"
+                  mconcat [ "I have "
+                  , Number' "count"
+                  , " dogs, the newest of which is Hodor!"
                   ]
                 ))
-                [ Plaintext "I have "
-                , Number "count"
-                , Plaintext " dogs, the newest of which is unknown!"
-                ]
-              ]
+                (mconcat [ "I have "
+                , Number' "count"
+                , " dogs, the newest of which is unknown!"
+                ])
+              ])
 
       flatten x `shouldBe` y
 
@@ -112,18 +112,18 @@ spec = describe "compiler" $ do
       g [c Many mempty, c Zero mempty] `shouldBe` universe
 
     it "copies the wildcard stream to new rules" $ do
-      let xs = [Plaintext "foo"]
+      let xs = "foo"
       let c = (,)
       let w = id
       let g ys = toList (f ys (w xs))
 
       g [] `shouldBe` (flip c xs <$> (universe :: [PluralRule]))
 
-      g [c Many [Plaintext "bar"], c Zero mempty] `shouldBe`
-        [c Many [Plaintext "bar"], c Zero mempty, c One xs, c Two xs, c Few xs]
+      g [c Many "bar", c Zero mempty] `shouldBe`
+        [c Many "bar", c Zero mempty, c One xs, c Two xs, c Few xs]
 
     it "returns full list of rules unmodified (as non-empty)" $ do
-      let c x y = (x, [Plaintext y])
+      let c = (,)
       let xs = [c Two "foo", c Many "", c Zero "bar", c One "baz", c Few ""]
 
-      f xs [Plaintext "any"] `shouldBe` fromList xs
+      f xs "any" `shouldBe` fromList xs

--- a/test/Intlc/ICUSpec.hs
+++ b/test/Intlc/ICUSpec.hs
@@ -1,0 +1,28 @@
+{-# OPTIONS_GHC -Wno-unrecognised-pragmas #-}
+{-# HLINT ignore "Monoid law, left identity" #-}
+{-# HLINT ignore "Monoid law, right identity" #-}
+
+module Intlc.ICUSpec where
+
+import           Intlc.ICU
+import           Prelude
+import           Test.Hspec
+
+spec :: Spec
+spec = describe "ICU AST" $ do
+  let a = Char' 'a'
+  let b = Char' 'b'
+  let c = Char' 'c'
+
+  describe "semigroup" $ do
+    describe "is lawful with respect to" $ do
+      it "associativity" $ do
+        (a <> b) <> c `shouldBe` a <> (b <> c)
+
+  describe "monoid" $ do
+    describe "is lawful with respect to" $ do
+      it "left identity" $ do
+        a <> mempty `shouldBe` a
+
+      it "right identity" $ do
+        mempty <> a `shouldBe` a

--- a/test/Intlc/LinterSpec.hs
+++ b/test/Intlc/LinterSpec.hs
@@ -15,42 +15,42 @@ spec = describe "linter" $ do
       let lint = lintWith' redundantSelectRule
 
       it "succeeds on select with any non-wildcard case" $ do
-        lint (Message [SelectNamed "x" (pure ("y", []))])
+        lint (Message (SelectNamed' "x" (pure ("y", mempty))))
           `shouldBe` Success
-        lint (Message [SelectNamedWild "x" (pure ("y", [])) []])
+        lint (Message (SelectNamedWild' "x" (pure ("y", mempty)) mempty))
           `shouldBe` Success
 
       it "fails on selects with only a wildcard" $ do
-        let s = SelectWild
+        let s = SelectWild'
 
-        lint (Message [s "x" [s "y" []], s "z" []])
+        lint (Message $ mconcat [s "x" (s "y" mempty), s "z" mempty])
           `shouldBe` Failure (pure $ RedundantSelect ("x" :| ["y", "z"]))
 
     describe "redundant plural" $ do
       let lint = lintWith' redundantPluralRule
 
       it "succeeds on exact cardinal plural" $ do
-        lint (Message [CardinalExact "x" (pure (PluralExact "42", []))])
+        lint (Message $ CardinalExact' "x" (pure (PluralExact "42", mempty)))
           `shouldBe` Success
 
       it "succeeds on ordinal plural with any non-wildcard case" $ do
-        lint (Message [Ordinal "x" [(PluralExact "42", [])] [] []])
+        lint (Message $ Ordinal' "x" [(PluralExact "42", mempty)] [] mempty)
           `shouldBe` Success
-        lint (Message [Ordinal "x" [] [(Two, [])] []])
+        lint (Message $ Ordinal' "x" [] [(Two, mempty)] mempty)
           `shouldBe` Success
 
       it "succeeds on inexact cardinal plural with any non-wildcard case" $ do
-        lint (Message [CardinalInexact "x" [(PluralExact "42", [])] [] []])
+        lint (Message $ CardinalInexact' "x" [(PluralExact "42", mempty)] [] mempty)
           `shouldBe` Success
-        lint (Message [CardinalInexact "x" [] [(Two, [])] []])
+        lint (Message $ CardinalInexact' "x" [] [(Two, mempty)] mempty)
           `shouldBe` Success
 
       it "fails on ordinal plural with only a wildcard" $ do
-        lint (Message [Ordinal "x" [] [] []])
+        lint (Message $ Ordinal' "x" [] [] mempty)
           `shouldBe` Failure (pure . RedundantPlural . pure $ "x")
 
       it "fails on inexact cardinal plural with only a wildcard" $ do
-        lint (Message [CardinalInexact "x" [] [] []])
+        lint (Message $ CardinalInexact' "x" [] [] mempty)
           `shouldBe` Failure (pure . RedundantPlural . pure $ "x")
 
   describe "internal" $ do
@@ -58,49 +58,46 @@ spec = describe "linter" $ do
       let lint = lintWith' unsupportedUnicodeRule
 
       it "does not lint text with emoji" $ do
-        lint (Message [Plaintext "Message with an emoji ❤️ 🥺"])
+        lint (Message "Message with an emoji ❤️ 🥺")
           `shouldBe` Failure (pure $ InvalidNonAsciiCharacter (fromList "❤️🥺"))
 
       it "does not lint text that is deeply nested with emoji" $ do
-        lint (Message [Callback "Hello" [], Bool "Hello" [Plaintext "Message with an emoji 🥺"] []])
+        lint (Message $ mconcat [Callback' "Hello" mempty, Bool' "Hello" "Message with an emoji 🥺" mempty])
           `shouldBe` Failure (fromList [InvalidNonAsciiCharacter (fromList ['🥺'])])
 
       it "lints streams without emoji" $ do
-        lint (Message [Plaintext "Text without emoji"]) `shouldBe` Success
+        lint (Message "Text without emoji") `shouldBe` Success
 
     describe "interpolations" $ do
       let lint = lintWith' interpolationsRule
       -- An example interpolation that's affected by this lint rule.
-      let f = SelectWild
+      let f = SelectWild'
 
-      it "lints streams with 1 plain text node" $ do
-        lint (Message [Plaintext "yay"]) `shouldBe` Success
-
-      it "lints streams with 2 or more plain text node" $ do
-        lint (Message [Plaintext "yay", Plaintext "Hello"]) `shouldBe` Success
+      it "lints streams with no interpolations" $ do
+        lint (Message "hello world") `shouldBe` Success
 
       it "lints streams with 1 simple interpolation" $ do
-        lint (Message [String "Hello"]) `shouldBe` Success
+        lint (Message (String' "Hello")) `shouldBe` Success
 
       it "lints streams with 1 complex interpolation" $ do
-        lint (Message [f "Hello" []]) `shouldBe` Success
+        lint (Message (f "Hello" mempty)) `shouldBe` Success
 
       it "lints streams with 1 complex interpolation and 1 simple interpolation" $ do
-        lint (Message [f "Hello" [], Plaintext "hello"]) `shouldBe` Success
+        lint (Message $ mconcat [f "Hello" mempty, "hello"]) `shouldBe` Success
 
       it "lints plurals and callbacks" $ do
-        let cb = flip Callback mempty
-        lint (Message [cb "x", cb "y"]) `shouldBe` Success
+        let cb = flip Callback' mempty
+        lint (Message $ mconcat [cb "x", cb "y"]) `shouldBe` Success
 
-        let p n = Ordinal n [] (pure (Zero, [])) []
-        lint (Message [p "x", p "y"]) `shouldBe` Success
+        let p n = Ordinal' n [] (pure (Zero, mempty)) mempty
+        lint (Message $ mconcat [p "x", p "y"]) `shouldBe` Success
 
       it "does not lint streams with 2 or more complex interpolations" $ do
-        lint (Message [f "x" [], f "y" []])
+        lint (Message $ mconcat [f "x" mempty, f "y" mempty])
           `shouldBe` Failure (pure $ TooManyInterpolations ("x" :| ["y"]))
-        lint (Message [f "x" [], f "y" [], f "z" []])
+        lint (Message $ mconcat [f "x" mempty, f "y" mempty, f "z" mempty])
           `shouldBe` Failure (pure $ TooManyInterpolations ("x" :| ["y", "z"]))
 
       it "does not lint nested streams" $ do
-        lint (Message [f "outer" [f "inner" []]])
+        lint (Message $ mconcat [f "outer" (f "inner" mempty)])
           `shouldBe` Failure (pure $ TooManyInterpolations ("outer" :| ["inner"]))

--- a/test/Intlc/Parser/JSONSpec.hs
+++ b/test/Intlc/Parser/JSONSpec.hs
@@ -90,14 +90,14 @@ spec = describe "JSON parser" $ do
       "x": { "message": "a'" },
       "y": { "message": "'b" }
     }|] `shouldParse` fromList
-      [ ("x", msg [ICU.Plaintext "a'"])
-      , ("y", msg [ICU.Plaintext "'b"])
+      [ ("x", msg "a'")
+      , ("y", msg "'b")
       ]
 
     parse [r|{
       "x": { "message": "a'{b" },
       "y": { "message": "c}'d" }
     }|] `shouldParse` fromList
-      [ ("x", msg [ICU.Plaintext "a{b"])
-      , ("y", msg [ICU.Plaintext "c}'d"])
+      [ ("x", msg "a{b")
+      , ("y", msg "c}'d")
       ]


### PR DESCRIPTION
Rather than our `Node` constructors containing `[Node]`, they now contain `Node` in those places, and an additional `Node` sibling. In a sense this is directly embedding Haskell's singly-linked list into our core AST type, hence the addition of the `Fin` constructor, equivalent to list `Nil`. Alternative primed constructors are supplied via patterns, so instead of `String x Fin` you can write `String' x`.

With this PR alone it's a relatively neutral change, but it enables more powerful recursion schemes in #171.

Additionally an `IsString` instance has been added, which can be backported to the previous AST representation if this PR isn't merged. It transforms `"xy"` directly into `Char 'x' (Char 'y' Fin)` (previously `Plaintext "xy"`).

Oh, and with us embracing holding chars rather than strings, we can say goodbye to `mergePlaintext`.

Before (with `IsString` sugar): `["Hello ", String "name", etc]`

After: `mconcat ["Hello", String' "name", etc]`