### PR TITLE
Add pattern functor and utilise recursion schemes/catamorphisms

### DIFF
--- a/intlc.cabal
+++ b/intlc.cabal
@@ -25,6 +25,7 @@ common common
     , extra                ^>=1.7
     , mtl                  ^>=2.2
     , optics               ^>=0.4
+    , recursion-schemes    ^>=5.2
     , relude               ^>=1.1
     , text                 ^>=1.2
     , validation           ^>=1.1

--- a/lib/Intlc/Compiler.hs
+++ b/lib/Intlc/Compiler.hs
@@ -87,8 +87,8 @@ expandRules ys w = fromList $ unionBy ((==) `on` caseRule) (toList ys) extraCase
         allRules = universe
         caseRule (x, _) = x
 
-mapSelectCase :: (ICU.Node -> ICU.Node) -> ICU.SelectCase -> ICU.SelectCase
+mapSelectCase :: (a -> a) -> ICU.SelectCaseF a -> ICU.SelectCaseF a
 mapSelectCase = second
 
-mapPluralCase :: (ICU.Node -> ICU.Node) -> ICU.PluralCase a -> ICU.PluralCase a
+mapPluralCase :: (b -> b) -> ICU.PluralCaseF a b -> ICU.PluralCaseF a b
 mapPluralCase = second

--- a/lib/Intlc/ICU.hs
+++ b/lib/Intlc/ICU.hs
@@ -202,7 +202,7 @@ getNext (SelectWild _ _ x)          = Just x
 getNext (SelectNamedWild _ _ _ x)   = Just x
 getNext (Callback _ _ x)            = Just x
 
-getPluralCaseNode :: PluralCase a -> Node
+getPluralCaseNode :: PluralCaseF a b -> b
 getPluralCaseNode = snd
 
 -- Pulls out the next node and replaces it, if any, with `Fin`.

--- a/lib/Intlc/ICU.hs
+++ b/lib/Intlc/ICU.hs
@@ -155,36 +155,6 @@ data PluralRule
 type SelectCase = SelectCaseF Node
 type SelectCaseF a = (Text, a)
 
-getInterpolationChildren :: Node -> Maybe Node
-getInterpolationChildren = fmap snd . getInterpolation
-
--- Returns a tuple of an interpolation's argument name and its concatenated
--- children.
-getInterpolation :: Node -> Maybe (Arg, Node)
-getInterpolation Fin {}          = Nothing
-getInterpolation Char {}         = Nothing
-getInterpolation String {}       = Nothing
-getInterpolation Number {}       = Nothing
-getInterpolation Date {}         = Nothing
-getInterpolation Time {}         = Nothing
-getInterpolation PluralRef {}    = Nothing
-getInterpolation x@(Bool {})     = Just (name x, trueCase x <> falseCase x)
-getInterpolation (CardinalExact n ls _)        = Just (n, getPluralCaseNode `foldMap` ls)
-getInterpolation (CardinalInexact n ls rs w _) = Just . (n,) $ mconcat
-  [ getPluralCaseNode `foldMap` ls
-  , getPluralCaseNode `foldMap` rs
-  , w
-  ]
-getInterpolation (Ordinal n xs ys w _)         = Just . (n,) $ mconcat
-  [ getPluralCaseNode `foldMap` xs
-  , getPluralCaseNode `foldMap` ys
-  , w
-  ]
-getInterpolation (SelectNamed n xs _)        = Just (n, snd `foldMap` xs)
-getInterpolation (SelectWild n xs _)         = Just (n, xs)
-getInterpolation (SelectNamedWild n xs ys _) = Just (n, snd `foldMap` xs <> ys)
-getInterpolation (Callback n xs _) = Just (n, xs)
-
 getNext :: Node -> Maybe Node
 getNext Fin                         = Nothing
 getNext (Char _ x)                  = Just x
@@ -201,9 +171,6 @@ getNext (SelectNamed _ _ x)         = Just x
 getNext (SelectWild _ _ x)          = Just x
 getNext (SelectNamedWild _ _ _ x)   = Just x
 getNext (Callback _ _ x)            = Just x
-
-getPluralCaseNode :: PluralCaseF a b -> b
-getPluralCaseNode = snd
 
 -- Pulls out the next node and replaces it, if any, with `Fin`.
 sever :: Node -> (Node, Maybe Node)

--- a/test/Intlc/LinterSpec.hs
+++ b/test/Intlc/LinterSpec.hs
@@ -46,11 +46,11 @@ spec = describe "linter" $ do
           `shouldBe` Success
 
       it "fails on ordinal plural with only a wildcard" $ do
-        lint (Message $ Ordinal' "x" [] [] mempty)
+        lint (Message $ Callback' "y" (Ordinal' "x" [] [] mempty))
           `shouldBe` Failure (pure . RedundantPlural . pure $ "x")
 
       it "fails on inexact cardinal plural with only a wildcard" $ do
-        lint (Message $ CardinalInexact' "x" [] [] mempty)
+        lint (Message $ Callback' "y" (CardinalInexact' "x" [] [] mempty))
           `shouldBe` Failure (pure . RedundantPlural . pure $ "x")
 
   describe "internal" $ do


### PR DESCRIPTION
Requires #170, else the catamorphism can no longer handle recursion in its entirety. Closes #48.

This is a pretty substantial PR conceptually. Aside from being fun and interesting, I think it also makes bugs like #101 less likely. Recursion schemes enable us to no longer explicitly recurse and instead, in the case of catamorphisms, merely handle the gathered data at each layer. It's essentially abstracting out the explicit act of recursing, so instead of in that sense saying how data will be transformed, we instead say what we'll do with said data.

`NodeF a` is a pattern functor rewrite of `Node`. Wherever `Node` references itself recursively, the recursive references are replaced with a reference to type argument `a`. This allows us to derive base typeclass instances like `Functor` and, more relevantly, `Recursive` and `Corecursive` instances which come from the [recursion-schemes](https://github.com/recursion-schemes/recursion-schemes) package. `NodeF` could be generated by [`makeBaseFunctor`](https://hackage.haskell.org/package/recursion-schemes-5.2.2.2/docs/Data-Functor-Foldable-TH.html#v:makeBaseFunctor), but I think it's helpful to see how the types relate without the magic of metaprogramming.

If you're wondering how `NodeF a` can ever become `Node` and not just end up as `NodeF (NodeF (NodeF ..))`, check out [`Fix`](https://hackage.haskell.org/package/data-fix-0.3.2/docs/Data-Fix.html#t:Fix). It's a bit trippy.

The major winners of this PR are plural expansion and lint rules. Lots of error-prone boilerplate has been removed.

As with lots of other things Haskell, when there are new problems to solve we can do them in a generalised way. Knowledge of recursion schemes is reusable.

I haven't figured out flattening via recursion schemes yet. It's on the list alongside utilising the pattern functor to hold additional information (see https://github.com/unsplash/intlc/issues/48#issuecomment-1199563996).