### PR TITLE
GHC 9.2.4

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -15,7 +15,7 @@ jobs:
       - uses: haskell/actions/setup@v2
         id: setup-haskell
         with:
-          ghc-version: 9.0.2
+          ghc-version: 9.2.4
       - run: cabal freeze
       - uses: actions/cache@v3
         with:
@@ -30,7 +30,7 @@ jobs:
       - uses: haskell/actions/setup@v2
         id: setup-haskell
         with:
-          ghc-version: 9.0.2
+          ghc-version: 9.2.4
       - run: cabal freeze
       - uses: actions/cache@v3
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,7 +21,7 @@ jobs:
       - uses: haskell/actions/setup@v2
         id: setup-haskell
         with:
-          ghc-version: 9.0.2
+          ghc-version: 9.2.4
       - run: cabal freeze
       - uses: actions/cache@v3
         with:

--- a/README.md
+++ b/README.md
@@ -88,4 +88,6 @@ The description is optional and ignored by intlc. It can be used documentatively
 
 ## Contributing
 
-Check out `ARCHITECTURE.md`. Currently building against GHC 9.2.4.
+Check out `ARCHITECTURE.md`.
+
+Currently building against GHC 9.2.4. A Nix flake is included with all necessary dependencies. Contributors on Apple silicon will need to source GHC and HLS externally, for example via ghcup.

--- a/README.md
+++ b/README.md
@@ -88,4 +88,4 @@ The description is optional and ignored by intlc. It can be used documentatively
 
 ## Contributing
 
-Check out `ARCHITECTURE.md`. Currently building against GHC 9.0.2.
+Check out `ARCHITECTURE.md`. Currently building against GHC 9.2.4.

--- a/flake.nix
+++ b/flake.nix
@@ -7,30 +7,40 @@
   outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
       let pkgs = nixpkgs.legacyPackages.${system};
+
+          # Ensure this is available for both GHC and HLS in ghcup for non-Nix
+          # contributors.
           ghcVer = "924";
+
           # HLS in nixpkgs is marked as broken on aarch64-darwin via LLVM 7,
           # see:
           #   https://github.com/NixOS/nixpkgs/blob/a410420844fe1ad6415cf9586308fe7538cc7584/pkgs/development/compilers/llvm/7/compiler-rt/default.nix#L108
           #
           # See also in unsplash/intlc: #162, #167
-          hls = if system == flake-utils.lib.system.aarch64-darwin
+          #
+          # GHC and HLS need to be sourced from the same place to ensure that
+          # HLS was compiled against that same version of GHC, else we'll see
+          # "ABIs don't match".
+          hask = if system == flake-utils.lib.system.aarch64-darwin
             then [ ]
-            else [ (pkgs.haskell-language-server.override { supportedGhcVersions = [ ghcVer ];}) ];
+            else with pkgs; [
+              haskell.compiler."ghc${ghcVer}"
+              (haskell-language-server.override { supportedGhcVersions = [ ghcVer ];})
+            ];
       in {
+        # Ensure that everything here has a binary cached in Hydra on all
+        # supported architectures; avoid `haskell.packages.ghcXXX.package`.
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [
             git
 
-            # Ensure that everything here has a binary cached in Hydra on all
-            # supported architectures; avoid `haskell.packages.ghcXXX.package`.
-            haskell.compiler."ghc${ghcVer}"
             cabal-install
             haskellPackages.hspec-golden
 
             # For typechecking golden output
             nodejs
             yarn
-          ] ++ hls;
+          ] ++ hask;
         };
       });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -7,6 +7,7 @@
   outputs = { self, nixpkgs, flake-utils }:
     flake-utils.lib.eachDefaultSystem (system:
       let pkgs = nixpkgs.legacyPackages.${system};
+          ghcVer = "924";
           # HLS in nixpkgs is marked as broken on aarch64-darwin via LLVM 7,
           # see:
           #   https://github.com/NixOS/nixpkgs/blob/a410420844fe1ad6415cf9586308fe7538cc7584/pkgs/development/compilers/llvm/7/compiler-rt/default.nix#L108
@@ -14,7 +15,7 @@
           # See also in unsplash/intlc: #162, #167
           hls = if system == flake-utils.lib.system.aarch64-darwin
             then [ ]
-            else [ pkgs.haskell-language-server ];
+            else [ (pkgs.haskell-language-server.override { supportedGhcVersions = [ ghcVer ];}) ];
       in {
         devShells.default = pkgs.mkShell {
           buildInputs = with pkgs; [
@@ -22,7 +23,7 @@
 
             # Ensure that everything here has a binary cached in Hydra on all
             # supported architectures; avoid `haskell.packages.ghcXXX.package`.
-            haskell.compiler.ghc924
+            haskell.compiler."ghc${ghcVer}"
             cabal-install
             haskellPackages.hspec-golden
 

--- a/flake.nix
+++ b/flake.nix
@@ -20,9 +20,9 @@
           buildInputs = with pkgs; [
             git
 
-            # We use mainline Haskell packages rather than specifying a custom
-            # GHC version to ensure everything we want is cached in Hydra.
-            ghc
+            # Ensure that everything here has a binary cached in Hydra on all
+            # supported architectures; avoid `haskell.packages.ghcXXX.package`.
+            haskell.compiler.ghc924
             cabal-install
             haskellPackages.hspec-golden
 

--- a/internal/Main.hs
+++ b/internal/Main.hs
@@ -20,7 +20,7 @@ lint :: MonadIO m => Dataset Translation -> m ()
 lint xs = whenJust (lintDatasetInternal xs) $ die . T.unpack
 
 compileExpandedPlurals :: MonadIO m => Dataset Translation -> m ()
-compileExpandedPlurals = putTextLn . compileDataset . fmap (\x -> x { message = expandPlurals (message x) })
+compileExpandedPlurals = putTextLn . compileDataset . fmap (\x -> x { message = expandPlurals x.message })
 
 tryGetParsedStdin :: IO (Dataset Translation)
 tryGetParsedStdin = parserDie =<< getParsedStdin

--- a/intlc.cabal
+++ b/intlc.cabal
@@ -5,17 +5,11 @@ license:                   MIT
 build-type:                Simple
 
 common common
-  default-language:        Haskell2010
+  default-language:        GHC2021
   default-extensions:
     LambdaCase
     NoImplicitPrelude
     OverloadedStrings
-    -- These are included in GHC2021.
-    DeriveGeneric
-    FlexibleContexts
-    GeneralizedNewtypeDeriving
-    NamedFieldPuns
-    TupleSections
   ghc-options:
     -Wall
   build-depends:

--- a/intlc.cabal
+++ b/intlc.cabal
@@ -19,7 +19,7 @@ common common
   ghc-options:
     -Wall
   build-depends:
-      base                 ^>=4.15
+      base                 ^>=4.16
     , bytestring           ^>=0.11
     , containers           ^>=0.6
     , extra                ^>=1.7

--- a/intlc.cabal
+++ b/intlc.cabal
@@ -9,6 +9,7 @@ common common
   default-extensions:
     LambdaCase
     NoImplicitPrelude
+    OverloadedRecordDot
     OverloadedStrings
   ghc-options:
     -Wall

--- a/lib/Intlc/Compiler.hs
+++ b/lib/Intlc/Compiler.hs
@@ -40,7 +40,7 @@ compileFlattened :: Dataset Translation -> Text
 compileFlattened = JSON.compileDataset . mapMsgs flatten
 
 mapMsgs :: (ICU.Message -> ICU.Message) -> Dataset Translation -> Dataset Translation
-mapMsgs f = fmap $ \x -> x { message = f (message x) }
+mapMsgs f = fmap $ \x -> x { message = f x.message }
 
 flatten :: ICU.Message -> ICU.Message
 flatten = ICU.Message . go mempty . ICU.unMessage

--- a/lib/Intlc/ICU.hs
+++ b/lib/Intlc/ICU.hs
@@ -1,7 +1,6 @@
 -- This module defines an AST for ICU messages. We do not necessarily behave
 -- identically to other implementations.
 {-# LANGUAGE DeriveAnyClass     #-}
-{-# LANGUAGE DeriveTraversable  #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE PatternSynonyms    #-}
 {-# LANGUAGE TypeFamilies       #-}


### PR DESCRIPTION
This PR upgrades us to GHC 9.2. I don't think any of the issues raised with #161 (hence #162) apply any more.

HLS is still unavailable on Apple silicon via Nix (without building from source), and GHC and HLS need to be sourced together. This is documented in the flake.