### PR TITLE
Add ICU prettifier

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,27 @@ welcome:
   Redundant select: name
 ```
 
+### Formatting
+
+Pretty-print an ICU message. Useful for inspecting larger messages such as flattened ones.
+
+```console
+$ cat translations.json
+{"tagline": {"message":"{hasTags, boolean, true {{type, select, overLimit {{upperLimit, number}+ best free {formattedListOfTags} photos on Unsplash} belowLimit {{photoTotal, number} best free {formattedListOfTags} photos on Unsplash}}} false {{type, select, overLimit {{upperLimit, number}+ best free photos on Unsplash} belowLimit {{photoTotal, number} best free photos on Unsplash}}}}"}}
+$ intlc prettify $(cat translations.json | jq -r .tagline.message)
+{hasTags, boolean,
+  true {{type, select,
+    overLimit {{upperLimit, number}+ best free {formattedListOfTags} photos on Unsplash}
+    belowLimit {{photoTotal, number} best free {formattedListOfTags} photos on Unsplash}
+  }}
+  false {{type, select,
+    overLimit {{upperLimit, number}+ best free photos on Unsplash}
+    belowLimit {{photoTotal, number} best free photos on Unsplash}
+  }}
+}
+
+```
+
 ## Schema
 
 Translation files should be encoded as JSON and might look something like this:

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ Take a JSON object of ICU messages, and a locale, and output TypeScript to stdou
 
 ```console
 $ cat translations.json
-{"welcome": {"message": "Hello {name}"}}
+{"welcome":{"message": "Hello {name}"}}
 $ intlc compile translations.json -l en-US > translations.ts
 $ cat translations.ts
 export const welcome: (x: { name: string }) => string = x => `Hello ${x.name}`
@@ -59,7 +59,7 @@ Lint against suboptimal use of ICU syntax.
 
 ```console
 $ cat translations.json
-{"welcome": {"message": "Hello {name, select, other {{name}}}"}}
+{"welcome":{"message": "Hello {name, select, other {{name}}}"}}
 $ intlc lint translation.json
 welcome:
   Redundant select: name

--- a/cli/CLI.hs
+++ b/cli/CLI.hs
@@ -8,6 +8,7 @@ data Opts
   = Compile FilePath Locale
   | Flatten FilePath
   | Lint    FilePath
+  | Prettify Text
 
 getOpts :: IO Opts
 getOpts = execParser (info (opts <**> helper) (progDesc h))
@@ -15,9 +16,10 @@ getOpts = execParser (info (opts <**> helper) (progDesc h))
 
 opts :: Parser Opts
 opts = subparser . mconcat $
-  [ command "compile" (info (compile <**> helper) mempty)
-  , command "flatten" (info (flatten <**> helper) mempty)
-  , command "lint"    (info (lint    <**> helper) mempty)
+  [ command "compile"  (info (compile  <**> helper) mempty)
+  , command "flatten"  (info (flatten  <**> helper) mempty)
+  , command "lint"     (info (lint     <**> helper) mempty)
+  , command "prettify" (info (prettify <**> helper) mempty)
   ]
 
 compile :: Parser Opts
@@ -29,8 +31,14 @@ flatten = Flatten <$> pathp
 lint :: Parser Opts
 lint = Lint <$> pathp
 
+msgp :: Parser Text
+msgp = argument str (metavar "message")
+
 pathp :: Parser FilePath
 pathp = argument str (metavar "filepath")
 
 localep :: Parser Locale
 localep = Locale <$> strOption (short 'l' <> long "locale")
+
+prettify :: Parser Opts
+prettify = Prettify <$> msgp

--- a/intlc.cabal
+++ b/intlc.cabal
@@ -70,6 +70,7 @@ library
     Intlc.Parser.Error
     Intlc.Parser.JSON
     Intlc.Parser.ICU
+    Intlc.Prettify
     Utils
 
 test-suite test-intlc
@@ -97,3 +98,4 @@ test-suite test-intlc
     Intlc.LinterSpec
     Intlc.Parser.JSONSpec
     Intlc.Parser.ICUSpec
+    Intlc.PrettifySpec

--- a/lib/Intlc/Backend/ICU/Compiler.hs
+++ b/lib/Intlc/Backend/ICU/Compiler.hs
@@ -17,9 +17,13 @@ import           Utils                 ((<>^))
 compileMsg :: Message -> Text
 compileMsg = node . unMessage
 
-node :: Node -> Text
-node ast = runReader (cata go ast) (0 :: Int) where
-  go :: Monad m => NodeF (m Text) -> m Text
+type Indents = Int
+
+type Compiler = Reader Indents
+
+node :: Formatting -> Node -> Text
+node fo ast = runReader (cata go ast) 0 where
+  go :: NodeF (Compiler Text) -> Compiler Text
   go = \case
     FinF -> pure mempty
 
@@ -27,7 +31,7 @@ node ast = runReader (cata go ast) (0 :: Int) where
 
     (BoolF { nameF, trueCaseF, falseCaseF, nextF }) ->
       let cs = sequence [("true",) <$> trueCaseF, ("false",) <$> falseCaseF]
-       in (boolean nameF <$> cs) <>^ nextF
+       in (boolean nameF =<< cs) <>^ nextF
 
     (StringF n next) -> (string n <>) <$> next
 
@@ -37,39 +41,39 @@ node ast = runReader (cata go ast) (0 :: Int) where
 
     (TimeF n fmt next) -> (time n fmt <>) <$> next
 
-    (CardinalExactF n xs next) -> (cardinal n <$> exactPluralCases xs) <>^ next
+    (CardinalExactF n xs next) -> (cardinal n =<< exactPluralCases xs) <>^ next
 
     (CardinalInexactF n xs ys w next) ->
       let cs = join <$> sequence [exactPluralCases xs, rulePluralCases ys, pure . wildcard <$> w]
-       in (cardinal n <$> cs) <>^ next
+       in (cardinal n =<< cs) <>^ next
 
     (OrdinalF n xs ys w next) ->
       let cs = join <$> sequence [exactPluralCases xs, rulePluralCases ys, pure . wildcard <$> w]
-       in (ordinal n <$> cs) <>^ next
+       in (ordinal n =<< cs) <>^ next
 
     (PluralRefF _ next) -> ("#" <>) <$> next
 
-    (SelectNamedF n xs y) -> (select n <$> selectCases xs) <>^ y
+    (SelectNamedF n xs y) -> (select n =<< selectCases xs) <>^ y
 
-    (SelectWildF n w x) -> (select n . pure . wildcard <$> w) <>^ x
+    (SelectWildF n w x) -> (select n . pure . wildcard =<< w) <>^ x
 
     (SelectNamedWildF n xs w next) ->
       let cs = (<>) <$> selectCases xs <*> (pure . wildcard <$> w)
-       in (select n <$> cs) <>^ next
+       in (select n =<< cs) <>^ next
 
     (CallbackF n xs next) -> (callback n <$> xs) <>^ next
 
-cardinal :: Arg -> [Case] -> Text
-cardinal n x = typedInterp "plural" n (pure . cases $ x)
+cardinal :: Arg -> [Case] -> Compiler Text
+cardinal n x = typedInterp "plural" n <$> (pure <$> cases x)
 
-ordinal :: Arg -> [Case] -> Text
-ordinal n x = typedInterp "selectordinal" n (pure . cases $ x)
+ordinal :: Arg -> [Case] -> Compiler Text
+ordinal n x = typedInterp "selectordinal" n <$> (pure <$> cases x)
 
-select :: Arg -> [Case] -> Text
-select n x = typedInterp "select" n (pure . cases $ x)
+select :: Arg -> [Case] -> Compiler Text
+select n x = typedInterp "select" n <$> (pure <$> cases x)
 
-boolean :: Arg -> [Case] -> Text
-boolean n x = typedInterp "boolean" n (pure . cases $ x)
+boolean :: Arg -> [Case] -> Compiler Text
+boolean n x = typedInterp "boolean" n <$> (pure <$> cases x)
 
 datetime :: Text -> Arg -> DateTimeFmt -> Text
 datetime t n f = typedInterp t n (pure . dateTimeFmt $ f)
@@ -100,8 +104,8 @@ callback n x = "<" <> unArg n <> ">" <> x <> "</" <> unArg n <> ">"
 
 type Case = (Text, Text)
 
-cases :: [Case] -> Text
-cases = unwords . fmap (uncurry case')
+cases :: [Case] -> Compiler Text
+cases = pure . unwords . fmap (uncurry case')
 
 case' :: Text -> Text -> Text
 case' n x = n <> " {" <> x <> "}"
@@ -109,7 +113,7 @@ case' n x = n <> " {" <> x <> "}"
 wildcard :: Text -> Case
 wildcard = ("other",)
 
-selectCases :: (Traversable t, Applicative f) => t (SelectCaseF (f Text)) -> f [Case]
+selectCases :: Traversable t => t (SelectCaseF (Compiler Text)) -> Compiler [Case]
 selectCases = fmap toList . traverse selectCaseF
 
 selectCaseF :: Functor f => SelectCaseF (f Text) -> f Case
@@ -118,19 +122,19 @@ selectCaseF (n, mx) = selectCase . (n,) <$> mx
 selectCase :: SelectCaseF Text -> Case
 selectCase = id
 
-exactPluralCases :: (Traversable t, Applicative f) => t (PluralCaseF PluralExact (f Text)) -> f [Case]
+exactPluralCases :: Traversable t => t (PluralCaseF PluralExact (Compiler Text)) -> Compiler [Case]
 exactPluralCases = fmap toList . traverse exactPluralCaseF
 
-exactPluralCaseF :: Functor f => PluralCaseF PluralExact (f Text) -> f Case
+exactPluralCaseF :: PluralCaseF PluralExact (Compiler Text) -> Compiler Case
 exactPluralCaseF (n, mx) = exactPluralCase . (n,) <$> mx
 
 exactPluralCase :: PluralCaseF PluralExact Text -> Case
 exactPluralCase (PluralExact n, x) = ("=" <> n, x)
 
-rulePluralCases :: (Traversable t, Applicative f) => t (PluralCaseF PluralRule (f Text)) -> f [Case]
+rulePluralCases :: Traversable t => t (PluralCaseF PluralRule (Compiler Text)) -> Compiler [Case]
 rulePluralCases = fmap toList . traverse rulePluralCaseF
 
-rulePluralCaseF :: Functor f => PluralCaseF PluralRule (f Text) -> f Case
+rulePluralCaseF :: PluralCaseF PluralRule (Compiler Text) -> Compiler Case
 rulePluralCaseF (r, mx) = rulePluralCase . (r,) <$> mx
 
 rulePluralCase :: PluralCaseF PluralRule Text -> Case

--- a/lib/Intlc/Backend/JSON/Compiler.hs
+++ b/lib/Intlc/Backend/JSON/Compiler.hs
@@ -3,7 +3,8 @@ module Intlc.Backend.JSON.Compiler where
 import           Data.List.Extra            (escapeJSON)
 import qualified Data.Map                   as M
 import qualified Data.Text                  as T
-import           Intlc.Backend.ICU.Compiler (compileMsg)
+import           Intlc.Backend.ICU.Compiler (Formatting (SingleLine),
+                                             compileMsg)
 import           Intlc.Core
 import           Prelude
 
@@ -34,7 +35,7 @@ compileDataset = obj . M.toList . M.map translation
 translation :: Translation -> Text
 translation Translation { message, backend, mdesc } = obj . fromList $ ys
   where ys =
-          [ ("message", strVal . compileMsg $ message)
+          [ ("message", strVal . compileMsg SingleLine $ message)
           , ("backend", backendVal)
           , ("description", maybe nullVal strVal mdesc)
           ]

--- a/lib/Intlc/Parser.hs
+++ b/lib/Intlc/Parser.hs
@@ -1,7 +1,10 @@
 module Intlc.Parser where
 
+import qualified Data.Text             as T
 import           Intlc.Core
+import qualified Intlc.ICU             as ICU
 import           Intlc.Parser.Error    (ParseFailure)
+import           Intlc.Parser.ICU      (msg')
 import           Intlc.Parser.JSON     (ParserState (ParserState), dataset)
 import           Prelude
 import           Text.Megaparsec       (runParser)
@@ -9,6 +12,9 @@ import           Text.Megaparsec.Error
 
 parseDataset :: FilePath -> Text -> Either ParseFailure (Dataset Translation)
 parseDataset = runParser (evalStateT dataset (ParserState mempty))
+
+parseMessage :: Text -> Text -> Either ParseFailure ICU.Message
+parseMessage src = runParser msg' (T.unpack src)
 
 printErr :: ParseFailure -> String
 printErr = errorBundlePretty

--- a/lib/Intlc/Parser/ICU.hs
+++ b/lib/Intlc/Parser/ICU.hs
@@ -41,6 +41,14 @@ ident = label "alphabetic identifier" $ T.pack <$> some letterChar
 arg :: Parser Arg
 arg = Arg <$> ident
 
+-- | Parse a message until end of input.
+--
+-- To instead parse a message as part of a broader data structure, instead look
+-- at `msg` and its `endOfInput` state property.
+msg' :: Parsec ParseErr Text Message
+msg' = runReaderT msg cfg where
+  cfg = emptyState { endOfInput = eof }
+
 -- Parse a message until the end of input parser matches.
 msg :: Parser Message
 msg = msgTill =<< asks endOfInput

--- a/lib/Intlc/Prettify.hs
+++ b/lib/Intlc/Prettify.hs
@@ -1,0 +1,8 @@
+module Intlc.Prettify (prettify) where
+
+import           Intlc.Backend.ICU.Compiler (Formatting (..), compileMsg)
+import qualified Intlc.ICU                  as ICU
+import           Prelude
+
+prettify :: ICU.Message -> Text
+prettify = compileMsg MultiLine

--- a/test/Intlc/EndToEndSpec.hs
+++ b/test/Intlc/EndToEndSpec.hs
@@ -1,7 +1,8 @@
 module Intlc.EndToEndSpec (spec) where
 
 import qualified Data.Text                  as T
-import           Intlc.Backend.ICU.Compiler (compileMsg)
+import           Intlc.Backend.ICU.Compiler (Formatting (SingleLine),
+                                             compileMsg)
 import           Intlc.Compiler             (compileDataset, expandPlurals)
 import           Intlc.Core                 (Locale (Locale))
 import           Intlc.Parser               (parseDataset)
@@ -19,7 +20,7 @@ parseAndCompileDataset :: Text -> Either (NonEmpty Text) Text
 parseAndCompileDataset = compileDataset (Locale "en-US") <=< first (pure . show) . parseDataset "test"
 
 parseAndExpandMsg :: Text -> Either ParseFailure Text
-parseAndExpandMsg = fmap (compileMsg . expandPlurals) . parseMsg
+parseAndExpandMsg = fmap (compileMsg SingleLine . expandPlurals) . parseMsg
   where parseMsg = runParser (runReaderT msg (emptyState { endOfInput = eof })) "test"
 
 golden :: String -> Text -> Golden String

--- a/test/Intlc/PrettifySpec.hs
+++ b/test/Intlc/PrettifySpec.hs
@@ -1,0 +1,57 @@
+module Intlc.PrettifySpec where
+
+import qualified Data.Text      as T
+import           Intlc.ICU
+import           Intlc.Prettify (prettify)
+import           Prelude
+import           Test.Hspec
+
+spec :: Spec
+spec = describe "prettify" $ do
+  let f = prettify . Message
+
+  it "compiles to ICU with multiline formatting" $ do
+    let ast = mconcat
+          [ Bool' "hasTags"
+              (SelectNamed' "type"
+                (fromList
+                  [ ("overLimit", mconcat [Number' "upperLimit", "+ best free ", String' "formattedListOfTags", " photos on Unsplash"])
+                  , ("belowLimit", mconcat [Number' "photoTotal", " best free ", String' "formattedListOfTags", " photos on Unsplash"])
+                  ]
+                )
+              )
+              (SelectNamed' "type"
+                (fromList
+                  [ ("overLimit", mconcat [Number' "upperLimit", "+ best free photos on Unsplash"])
+                  , ("belowLimit", mconcat [Number' "photoTotal", " best free photos on Unsplash"])
+                  ]
+                )
+              )
+          , " "
+          , SelectNamed' "sibling"
+              (fromList
+                [ ("a", String' "foo")
+                , ("b", "bar")
+                ]
+              )
+          ]
+    let toTabs = T.replace "  " "\t"
+    -- Can't use QuasiQuotes as stylish-haskell removes the trailing whitespace
+    -- which exists in the current implementation.
+    let expected = T.intercalate "\n"
+          [ "{hasTags, boolean, "
+          , "  true {{type, select, "
+          , "    overLimit {{upperLimit, number}+ best free {formattedListOfTags} photos on Unsplash}"
+          , "    belowLimit {{photoTotal, number} best free {formattedListOfTags} photos on Unsplash}"
+          , "  }}"
+          , "  false {{type, select, "
+          , "    overLimit {{upperLimit, number}+ best free photos on Unsplash}"
+          , "    belowLimit {{photoTotal, number} best free photos on Unsplash}"
+          , "  }}"
+          , "} {sibling, select, "
+          , "  a {{foo}}"
+          , "  b {bar}"
+          , "}"
+          ]
+    -- Some trailing spaces are expected with the current implementation.
+    f ast `shouldBe` toTabs expected


### PR DESCRIPTION
Closes #129. For now the text content must be supplied as per the example instead of via stdin; a change here could be covered by #110.

```console
$ cat x.json
{
  "x": {
    "message": "{hasTags, boolean, true {{type, select, overLimit {{upperLimit, number}+ best free {formattedListOfTags} photos on Unsplash} belowLimit {{photoTotal, number} best free {formattedListOfTags} photos on Unsplash}}} false {{type, select, overLimit {{upperLimit, number}+ best free photos on Unsplash} belowLimit {{photoTotal, number} best free photos on Unsplash}}}} {another, select, a {{foo}} b {bar}}"
  }
}
$ intlc prettify $(cat x.json | jq -r .x.message)
{hasTags, boolean, 
	true {{type, select, 
		overLimit {{upperLimit, number}+ best free {formattedListOfTags} photos on Unsplash}
		belowLimit {{photoTotal, number} best free {formattedListOfTags} photos on Unsplash}
	}}
	false {{type, select, 
		overLimit {{upperLimit, number}+ best free photos on Unsplash}
		belowLimit {{photoTotal, number} best free photos on Unsplash}
	}}
} {another, select, 
	a {{foo}}
	b {bar}
}
```

There isn't really a satisfying way to format ICU messages across newlines. In this example the space between the `hasTags` and `another` interpolations needs to be preserved exactly as-is. Equally formatting in callbacks would be ambiguous, whereas the newlines and indentation inserted here aren't because it's within the syntactic structure of the interpolations.

I think this is okay because as per the feature request, and the part of the example I borrowed from there, we'll mostly be using this for interpolation-heavy, flattened messages.

In terms of implementation, the bulk of the change is refactoring the ICU compiler to be a little more abstract. Following that the change to support formatting is straightforward and centralised, essentially just using `Reader` `local` to increment a count according to how deeply nested into "cases" in the AST we are and inserting formatting accordingly.