### PR TITLE
AST annotations and fancy lint errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,16 @@ Lint against suboptimal use of ICU syntax.
 $ cat translations.json
 {"welcome":{"message": "Hello {name, select, other {{name}}}"}}
 $ intlc lint translation.json
-welcome:
-  Redundant select: name
+translations.json:1:32:
+  |
+1 | {"welcome":{"message": "Hello {name, select, other {{name}}}"}}
+  |                                ^^^^
+redundant-select: Select named `name` is redundant as it only contains a wildcard.
+
+Learn more: https://github.com/unsplash/intlc/wiki/Lint-rules-reference#redundant-select
 ```
+
+A reference for lint rules can be found in our wiki: https://github.com/unsplash/intlc/wiki/Lint-rules-reference
 
 ### Formatting
 

--- a/cli/Main.hs
+++ b/cli/Main.hs
@@ -15,7 +15,7 @@ main :: IO ()
 main = getOpts >>= \case
   Compile path loc -> tryGetParsedAtSansAnn path >>= compile loc
   Flatten path     -> tryGetParsedAtSansAnn path >>= flatten
-  Lint    path     -> tryGetParsedAtSansAnn path >>= lint
+  Lint    path     -> tryGetParsedAt path >>= lint
   Prettify msg     -> tryPrettify msg
 
 compile :: MonadIO m => Locale -> Dataset (Translation Message) -> m ()
@@ -26,7 +26,7 @@ compile loc = compileDataset loc >>> \case
 flatten :: MonadIO m => Dataset (Translation Message) -> m ()
 flatten = putTextLn . compileFlattened
 
-lint :: MonadIO m => Dataset (Translation Message) -> m ()
+lint :: MonadIO m => Dataset (Translation AnnMessage) -> m ()
 lint xs = whenJust (lintDatasetExternal xs) $ die . T.unpack
 
 tryPrettify :: MonadIO m => Text -> m ()

--- a/cli/Main.hs
+++ b/cli/Main.hs
@@ -4,7 +4,7 @@ import           CLI                (Opts (..), getOpts)
 import qualified Data.Text          as T
 import           Intlc.Compiler     (compileDataset, compileFlattened)
 import           Intlc.Core
-import           Intlc.ICU          (sansAnnMsg)
+import           Intlc.ICU          (AnnMessage, Message, sansAnnMsg)
 import           Intlc.Linter
 import           Intlc.Parser       (parseDataset, parseMessage, printErr)
 import           Intlc.Parser.Error (ParseFailure)
@@ -18,28 +18,28 @@ main = getOpts >>= \case
   Lint    path     -> tryGetParsedAtSansAnn path >>= lint
   Prettify msg     -> tryPrettify msg
 
-compile :: MonadIO m => Locale -> Dataset Translation -> m ()
+compile :: MonadIO m => Locale -> Dataset (Translation Message) -> m ()
 compile loc = compileDataset loc >>> \case
   Left es -> die . T.unpack . ("Invalid keys:\n" <>) . T.intercalate "\n" . fmap ("\t" <>) . toList $ es
   Right x -> putTextLn x
 
-flatten :: MonadIO m => Dataset Translation -> m ()
+flatten :: MonadIO m => Dataset (Translation Message) -> m ()
 flatten = putTextLn . compileFlattened
 
-lint :: MonadIO m => Dataset Translation -> m ()
+lint :: MonadIO m => Dataset (Translation Message) -> m ()
 lint xs = whenJust (lintDatasetExternal xs) $ die . T.unpack
 
 tryPrettify :: MonadIO m => Text -> m ()
 tryPrettify = either (die . printErr) (putTextLn . prettify . sansAnnMsg) . parseMessage "input"
 
-tryGetParsedAtSansAnn :: MonadIO m => FilePath -> m (Dataset Translation)
+tryGetParsedAtSansAnn :: MonadIO m => FilePath -> m (Dataset (Translation Message))
 tryGetParsedAtSansAnn = parserDie . fmap datasetSansAnn <=< getParsedAt
 
-tryGetParsedAt :: MonadIO m => FilePath -> m (Dataset AnnTranslation)
+tryGetParsedAt :: MonadIO m => FilePath -> m (Dataset (Translation AnnMessage))
 tryGetParsedAt = parserDie <=< getParsedAt
 
 parserDie :: MonadIO m => Either ParseFailure a -> m a
 parserDie = either (die . printErr) pure
 
-getParsedAt :: MonadIO m => FilePath -> m (Either ParseFailure (Dataset AnnTranslation))
+getParsedAt :: MonadIO m => FilePath -> m (Either ParseFailure (Dataset (Translation AnnMessage)))
 getParsedAt x = parseDataset x . decodeUtf8 <$> readFileBS x

--- a/internal/Main.hs
+++ b/internal/Main.hs
@@ -14,10 +14,10 @@ import           Prelude                     hiding (filter)
 
 main :: IO ()
 main = getOpts >>= \case
-  Lint path     -> tryGetParsedAtSansAnn path >>= lint
+  Lint path     -> tryGetParsedAt path >>= lint
   ExpandPlurals -> tryGetParsedStdinSansAnn >>= compileExpandedPlurals
 
-lint :: MonadIO m => Dataset (Translation Message) -> m ()
+lint :: MonadIO m => Dataset (Translation AnnMessage) -> m ()
 lint xs = whenJust (lintDatasetInternal xs) $ die . T.unpack
 
 compileExpandedPlurals :: MonadIO m => Dataset (Translation Message) -> m ()
@@ -28,9 +28,6 @@ tryGetParsedStdinSansAnn = parserDie . fmap datasetSansAnn =<< getParsedStdin
 
 tryGetParsedStdin :: IO (Dataset (Translation AnnMessage))
 tryGetParsedStdin = parserDie =<< getParsedStdin
-
-tryGetParsedAtSansAnn :: MonadIO m => FilePath -> m (Dataset (Translation Message))
-tryGetParsedAtSansAnn = parserDie . fmap datasetSansAnn <=< getParsedAt
 
 tryGetParsedAt :: MonadIO m => FilePath -> m (Dataset (Translation AnnMessage))
 tryGetParsedAt = parserDie <=< getParsedAt

--- a/intlc.cabal
+++ b/intlc.cabal
@@ -17,6 +17,7 @@ common common
       base                 ^>=4.16
     , bytestring           ^>=0.11
     , containers           ^>=0.6
+    , deriving-compat      ^>=0.6
     , extra                ^>=1.7
     , mtl                  ^>=2.2
     , optics               ^>=0.4

--- a/intlc.cabal
+++ b/intlc.cabal
@@ -16,9 +16,11 @@ common common
   build-depends:
       base                 ^>=4.16
     , bytestring           ^>=0.11
+    , comonad              ^>=5.0
     , containers           ^>=0.6
     , deriving-compat      ^>=0.6
     , extra                ^>=1.7
+    , free                 ^>=5.1
     , mtl                  ^>=2.2
     , optics               ^>=0.4
     , recursion-schemes    ^>=5.2

--- a/lib/Intlc/Backend/JSON/Compiler.hs
+++ b/lib/Intlc/Backend/JSON/Compiler.hs
@@ -6,6 +6,7 @@ import qualified Data.Text                  as T
 import           Intlc.Backend.ICU.Compiler (Formatting (SingleLine),
                                              compileMsg)
 import           Intlc.Core
+import           Intlc.ICU                  (Message)
 import           Prelude
 
 -- Assumes unescaped input.
@@ -29,10 +30,10 @@ obj :: [(Text, Text)] -> Text
 obj xs = "{" <> ys <> "}"
   where ys = T.intercalate "," . fmap (uncurry objPair) $ xs
 
-compileDataset :: Dataset Translation -> Text
+compileDataset :: Dataset (Translation Message) -> Text
 compileDataset = obj . M.toList . M.map translation
 
-translation :: Translation -> Text
+translation :: Translation Message -> Text
 translation Translation { message, backend, mdesc } = obj . fromList $ ys
   where ys =
           [ ("message", strVal . compileMsg SingleLine $ message)

--- a/lib/Intlc/Backend/JavaScript/Compiler.hs
+++ b/lib/Intlc/Backend/JavaScript/Compiler.hs
@@ -153,7 +153,7 @@ dateTimeFmt ICU.Full   = "full"
 emptyModule :: Text
 emptyModule = "export {}"
 
-buildReactImport :: Dataset Translation -> Maybe Text
+buildReactImport :: Dataset (Translation a) -> Maybe Text
 buildReactImport = flip pureIf text . any ((TypeScriptReact ==) . backend)
   where text = "import { ReactElement } from 'react'"
 

--- a/lib/Intlc/Core.hs
+++ b/lib/Intlc/Core.hs
@@ -1,6 +1,6 @@
 module Intlc.Core where
 
-import           Intlc.ICU (Message)
+import           Intlc.ICU (AnnMessage, Message, sansAnnMsg)
 import           Prelude
 
 -- Locales are too broad and too much of a moving target to validate, so this
@@ -22,6 +22,13 @@ data UnparsedTranslation = UnparsedTranslation
   }
   deriving (Show, Eq, Generic)
 
+data AnnTranslation = AnnTranslation
+  { amessage :: AnnMessage
+  , abackend :: Backend
+  , amdesc   :: Maybe Text
+  }
+  deriving (Show, Eq)
+
 data Translation = Translation
   { message :: Message
   , backend :: Backend
@@ -30,3 +37,13 @@ data Translation = Translation
   deriving (Show, Eq)
 
 type Dataset = Map Text
+
+datasetSansAnn :: Dataset AnnTranslation -> Dataset Translation
+datasetSansAnn = fmap translationSansAnn
+
+translationSansAnn :: AnnTranslation -> Translation
+translationSansAnn x = Translation
+  { message = sansAnnMsg x.amessage
+  , backend = x.abackend
+  , mdesc = x.amdesc
+  }

--- a/lib/Intlc/Core.hs
+++ b/lib/Intlc/Core.hs
@@ -15,22 +15,8 @@ data Backend
   | TypeScriptReact
   deriving (Show, Eq, Generic)
 
-data UnparsedTranslation = UnparsedTranslation
-  { umessage :: UnparsedMessage
-  , ubackend :: Backend
-  , umdesc   :: Maybe Text
-  }
-  deriving (Show, Eq, Generic)
-
-data AnnTranslation = AnnTranslation
-  { amessage :: AnnMessage
-  , abackend :: Backend
-  , amdesc   :: Maybe Text
-  }
-  deriving (Show, Eq)
-
-data Translation = Translation
-  { message :: Message
+data Translation a = Translation
+  { message :: a
   , backend :: Backend
   , mdesc   :: Maybe Text
   }
@@ -38,12 +24,12 @@ data Translation = Translation
 
 type Dataset = Map Text
 
-datasetSansAnn :: Dataset AnnTranslation -> Dataset Translation
+datasetSansAnn :: Dataset (Translation AnnMessage) -> Dataset (Translation Message)
 datasetSansAnn = fmap translationSansAnn
 
-translationSansAnn :: AnnTranslation -> Translation
+translationSansAnn :: Translation AnnMessage -> Translation Message
 translationSansAnn x = Translation
-  { message = sansAnnMsg x.amessage
-  , backend = x.abackend
-  , mdesc = x.amdesc
+  { message = sansAnnMsg x.message
+  , backend = x.backend
+  , mdesc = x.mdesc
   }

--- a/lib/Intlc/ICU.hs
+++ b/lib/Intlc/ICU.hs
@@ -3,13 +3,17 @@
 {-# LANGUAGE DeriveAnyClass     #-}
 {-# LANGUAGE DerivingStrategies #-}
 {-# LANGUAGE PatternSynonyms    #-}
+{-# LANGUAGE TemplateHaskell    #-}
 {-# LANGUAGE TypeFamilies       #-}
 
 module Intlc.ICU where
 
-import           Data.Functor.Foldable (Base, Corecursive, Recursive)
-import qualified Data.Text             as T
+import           Data.Eq.Deriving             (deriveEq1)
+import           Data.Functor.Foldable        (Base, Corecursive, Recursive,
+                                               cata, embed)
+import qualified Data.Text                    as T
 import           Prelude
+import           Text.Show.Deriving           (deriveShow1)
 
 newtype Message = Message Node
   deriving (Show, Eq)
@@ -143,6 +147,13 @@ data PluralRule
 
 type SelectCase = SelectCaseF Node
 type SelectCaseF a = (Text, a)
+
+-- Use Template Haskell to generate lifted typeclass instances for `NodeF`.
+-- Needs to appear after all the type aliases that `NodeF` references are
+-- defined. Anything else leaning on these instances must appear after this
+-- point.
+$(deriveShow1 ''NodeF)
+$(deriveEq1   ''NodeF)
 
 getNext :: Node -> Maybe Node
 getNext Fin                         = Nothing

--- a/lib/Intlc/Linter.hs
+++ b/lib/Intlc/Linter.hs
@@ -111,7 +111,7 @@ redundantSelectRule = nonEmpty . idents where
   idents = cata $ \case
     x@(i :< SelectWildF n _ _) -> f i n : fold x
     x                          ->         fold x
-  f i n = (i, RedundantSelect n)
+  f i n = (i + 1, RedundantSelect n)
 
 -- Plural interpolations with only wildcards are redundant: they could be
 -- replaced with plain number interpolations.
@@ -121,7 +121,7 @@ redundantPluralRule = nonEmpty . idents where
     x@(i :< CardinalInexactF n [] [] _ _) -> f i n : fold x
     x@(i :< OrdinalF         n [] [] _ _) -> f i n : fold x
     x                                     ->         fold x
-  f i n = (i, RedundantPlural n)
+  f i n = (i + 1, RedundantPlural n)
 
 -- Duplicate case names in select interpolations are redundant.
 duplicateSelectCasesRule :: Rule AnnExternalLint

--- a/lib/Intlc/Linter.hs
+++ b/lib/Intlc/Linter.hs
@@ -108,6 +108,11 @@ instance ShowErrorComponent ExternalLint where
       RedundantPlural {}     -> "redundant-plural"
       DuplicateSelectCase {} -> "duplicate-select-case"
       DuplicatePluralCase {} -> "duplicate-plural-case"
+  errorComponentLen = \case
+    RedundantSelect x       -> T.length (unArg x)
+    RedundantPlural x       -> T.length (unArg x)
+    DuplicateSelectCase _ x -> T.length x
+    DuplicatePluralCase _ x -> T.length x
 
 instance ShowErrorComponent InternalLint where
   showErrorComponent = T.unpack . uncurry wikify . (wikiName &&& msg) where
@@ -119,6 +124,9 @@ instance ShowErrorComponent InternalLint where
     wikiName = \case
       TooManyInterpolations {}    -> "too-many-interpolations"
       InvalidNonAsciiCharacter {} -> "invalid-non-ascii-char"
+  errorComponentLen = \case
+    TooManyInterpolations {}    -> 1
+    InvalidNonAsciiCharacter {} -> 1
 
 -- Select interpolations with only wildcards are redundant: they could be
 -- replaced with plain string interpolations.

--- a/lib/Intlc/Linter.hs
+++ b/lib/Intlc/Linter.hs
@@ -94,15 +94,17 @@ lintDatasetInternal = lintDatasetWith lintInternal
 
 instance ShowErrorComponent ExternalLint where
   showErrorComponent = (T.unpack .) $ \case
-    RedundantSelect x       -> "Redundant select: " <> unArg x
-    RedundantPlural x       -> "Redundant plural: " <> unArg x
-    DuplicateSelectCase x y -> "Duplicate select case: " <> unArg x <> ", " <> y
-    DuplicatePluralCase x y -> "Duplicate plural case: " <> unArg x <> ", " <> y
+    RedundantSelect x       -> "Select named `" <> unArg x <> "` is redundant as it only contains a wildcard."
+    RedundantPlural x       -> "Plural named `" <> unArg x <> "` is redundant as it only contains a wildcard."
+    DuplicateSelectCase x y -> "Select named `" <> unArg x <> "` contains a duplicate case named `" <> y <> "`."
+    DuplicatePluralCase x y -> "Plural named `" <> unArg x <> "` contains a duplicate `" <> y <> "` case."
 
 instance ShowErrorComponent InternalLint where
   showErrorComponent = (T.unpack .) $ \case
-    TooManyInterpolations xs   -> "Multiple complex interpolations: " <> T.intercalate ", " (fmap unArg . toList $ xs)
-    InvalidNonAsciiCharacter x -> "Following character disallowed: " <> T.singleton x
+    TooManyInterpolations xs   -> "Multiple \"complex\" non-plural interpolations in the same message are disallowed. Found names: " <> interps
+      where interps = T.intercalate ", " (fmap (qts . unArg) . toList $ xs)
+            qts x = "`" <> x <> "`"
+    InvalidNonAsciiCharacter x -> "Non-ASCII character `" <> T.singleton x <> "` is disallowed."
 
 -- Select interpolations with only wildcards are redundant: they could be
 -- replaced with plain string interpolations.

--- a/lib/Intlc/Linter.hs
+++ b/lib/Intlc/Linter.hs
@@ -59,19 +59,19 @@ lintInternal = lintWith
   ]
 
 -- Get the printable output from linting an entire dataset, if any.
-lintDatasetWith :: (Message -> Status a) -> (Text -> NonEmpty a -> Text) -> Dataset Translation -> Maybe Text
+lintDatasetWith :: (Message -> Status a) -> (Text -> NonEmpty a -> Text) -> Dataset (Translation Message) -> Maybe Text
 lintDatasetWith linter fmt xs = pureIf (not $ M.null lints) msg
   where lints = M.mapMaybe (statusToMaybe . linter . message) xs
         msg = T.intercalate "\n" $ uncurry fmt <$> M.assocs lints
 
-lintDatasetExternal :: Dataset Translation -> Maybe Text
+lintDatasetExternal :: Dataset (Translation Message) -> Maybe Text
 lintDatasetExternal = lintDatasetWith lintExternal . formatFailureWith $ \case
   RedundantSelect x       -> "Redundant select: " <> unArg x
   RedundantPlural x       -> "Redundant plural: " <> unArg x
   DuplicateSelectCase x y -> "Duplicate select case: " <> unArg x <> ", " <> y
   DuplicatePluralCase x y -> "Duplicate plural case: " <> unArg x <> ", " <> y
 
-lintDatasetInternal :: Dataset Translation -> Maybe Text
+lintDatasetInternal :: Dataset (Translation Message) -> Maybe Text
 lintDatasetInternal = lintDatasetWith lintInternal . formatFailureWith $ \case
   TooManyInterpolations xs   -> "Multiple complex interpolations: " <> T.intercalate ", " (fmap unArg . toList $ xs)
   InvalidNonAsciiCharacter x -> "Following character disallowed: " <> T.singleton x

--- a/lib/Intlc/Linter.hs
+++ b/lib/Intlc/Linter.hs
@@ -72,7 +72,7 @@ fmt :: ShowErrorComponent a => FilePath -> Text -> NonEmpty (WithAnn a) -> Text
 fmt path content lints = T.pack $ errorBundlePretty (buildParseErrBundle path content lints)
 
 buildParseErrBundle :: FilePath -> Text -> NonEmpty (WithAnn a) -> ParseErrorBundle Text a
-buildParseErrBundle path content lints = ParseErrorBundle (buildParseErr <$> lints) (buildPosState path content) where
+buildParseErrBundle path content lints = ParseErrorBundle (buildParseErr <$> lints) (buildPosState path content)
 
 buildParseErr :: WithAnn a -> ParseError Text a
 buildParseErr (i, x) = errFancy i . fancy . ErrorCustom $ x
@@ -154,11 +154,11 @@ duplicateSelectCasesRule = nonEmpty . cases where
     x@(_ :< SelectNamedF n ys _)       -> here n ys <> fold' x
     x@(_ :< SelectNamedWildF n ys _ _) -> here n ys <> fold' x
     x                                  ->              fold' x
-  here n xs = fmap (uncurry (f n) . (caseOffset &&& caseName)) . bunBy ((==) `on` caseName) $ xs
+  here n = fmap (uncurry (f n) . (caseOffset &&& caseName)) . bunBy ((==) `on` caseName)
     where caseName = fst
           caseOffset = uncurry calcCaseNameOffset . caseHead
           caseHead = second (extract . fst)
-  fold' = fold . fmap snd
+  fold' = foldMap snd
   f n i x = (i, DuplicateSelectCase n x)
 
 -- Duplicate cases in plural interpolations are redundant.
@@ -169,11 +169,11 @@ duplicatePluralCasesRule = nonEmpty . cases where
     x@(_ :< CardinalInexactF n ys zs _ _) -> here pluralExact n ys <> here pluralRule n zs <> fold' x
     x@(_ :< OrdinalF n ys zs _ _)         -> here pluralExact n ys <> here pluralRule n zs <> fold' x
     x                                     ->                                                  fold' x
-  here via n xs = fmap (uncurry (f n) . (caseOffset &&& (via . caseKey))) . bunBy ((==) `on` caseKey) $ xs
+  here via n = fmap (uncurry (f n) . (caseOffset &&& (via . caseKey))) . bunBy ((==) `on` caseKey)
     where caseKey = fst
           caseOffset = uncurry calcCaseNameOffset . first via . caseHead
           caseHead = second (extract . fst)
-  fold' = fold . fmap snd
+  fold' = foldMap snd
   f n i x = (i, DuplicatePluralCase n x)
 
 -- Our translation vendor has poor support for ICU syntax, and their parser

--- a/lib/Intlc/Parser.hs
+++ b/lib/Intlc/Parser.hs
@@ -4,17 +4,17 @@ import qualified Data.Text             as T
 import           Intlc.Core
 import qualified Intlc.ICU             as ICU
 import           Intlc.Parser.Error    (ParseFailure)
-import           Intlc.Parser.ICU      (msg')
+import           Intlc.Parser.ICU      (annMsg')
 import           Intlc.Parser.JSON     (ParserState (ParserState), dataset)
 import           Prelude
 import           Text.Megaparsec       (runParser)
 import           Text.Megaparsec.Error
 
-parseDataset :: FilePath -> Text -> Either ParseFailure (Dataset Translation)
+parseDataset :: FilePath -> Text -> Either ParseFailure (Dataset AnnTranslation)
 parseDataset = runParser (evalStateT dataset (ParserState mempty))
 
-parseMessage :: Text -> Text -> Either ParseFailure ICU.Message
-parseMessage src = runParser msg' (T.unpack src)
+parseMessage :: Text -> Text -> Either ParseFailure ICU.AnnMessage
+parseMessage src = runParser annMsg' (T.unpack src)
 
 printErr :: ParseFailure -> String
 printErr = errorBundlePretty

--- a/lib/Intlc/Parser.hs
+++ b/lib/Intlc/Parser.hs
@@ -10,7 +10,7 @@ import           Prelude
 import           Text.Megaparsec       (runParser)
 import           Text.Megaparsec.Error
 
-parseDataset :: FilePath -> Text -> Either ParseFailure (Dataset AnnTranslation)
+parseDataset :: FilePath -> Text -> Either ParseFailure (Dataset (Translation ICU.AnnMessage))
 parseDataset = runParser (evalStateT dataset (ParserState mempty))
 
 parseMessage :: Text -> Text -> Either ParseFailure ICU.AnnMessage

--- a/lib/Intlc/Parser/ICU.hs
+++ b/lib/Intlc/Parser/ICU.hs
@@ -59,12 +59,13 @@ msgTill = fmap Message . nodesTill
 
 -- Parse as many `Node`s as possible until the provided parser matches.
 nodesTill :: Parser a -> Parser Node
-nodesTill = fmap mconcat <$> manyTill node
+nodesTill end = go where
+  go = (Fin <$ end) <|> (node <*> go)
 
 -- The core parser of this module. Parse as many of these as you'd like until
 -- reaching an anticipated delimiter, such as a double quote in the surrounding
 -- JSON string or end of input in a REPL.
-node :: Parser Node
+node :: Parser (Node -> Node)
 node = choice
   [ interp
   , callback
@@ -72,31 +73,31 @@ node = choice
   -- `#`. When there's no such context, fail the parse in effect treating it
   -- as plaintext.
   , asks pluralCtxName >>= \case
-      Just n  -> PluralRef n Fin <$ string "#"
+      Just n  -> PluralRef n <$ string "#"
       Nothing -> empty
   , plaintext
   ]
 
 -- Parse a character or a potentially larger escape sequence.
-plaintext :: Parser Node
+plaintext :: Parser (Node -> Node)
 plaintext = choice
   [ try escaped
-  , flip Char Fin <$> L.charLiteral
+  , Char <$> L.charLiteral
   ]
 
 -- Follows ICU 4.8+ spec, see:
 --   https://unicode-org.github.io/icu/userguide/format_parse/messages/#quotingescaping
-escaped :: Parser Node
+escaped :: Parser (Node -> Node)
 escaped = apos *> choice
   -- Double escape two apostrophes as one, regardless of surrounding
   -- syntax: "''" -> "'"
-  [ flip Char Fin <$> apos
+  [ Char <$> apos
   -- Escape everything until another apostrophe, being careful of internal
   -- double escapes: "'{a''}'" -> "{a'}". Must ensure it doesn't surpass the
   -- bounds of the surrounding parser as per `endOfInput`.
   , try $ do
       eom <- asks endOfInput
-      head' <- flip Char Fin <$> synOpen
+      head' <- Char <$> synOpen
       -- Try and parse until end of input or a lone apostrophe. If end of input
       -- comes first then fail the parse.
       (tail', wasEom) <- someTill_ plaintext $ choice
@@ -104,9 +105,9 @@ escaped = apos *> choice
         , try $ False <$ apos <* notFollowedBy apos
         ]
       guard (not wasEom)
-      pure $ head' <> mconcat tail'
+      pure . foldr (.) id $ head' : tail'
   -- Escape the next syntax character as plaintext: "'{" -> "{"
-  , flip Char Fin <$> synAll
+  , Char <$> synAll
   ]
   where apos = char '\''
         synAll = synLone <|> synOpen <|> synClose
@@ -114,7 +115,7 @@ escaped = apos *> choice
         synOpen = char '{' <|> char '<'
         synClose = char '}' <|> char '>'
 
-callback :: Parser Node
+callback :: Parser (Node -> Node)
 callback = do
   (openPos, isClosing, oname) <- (,,) <$> (string "<" *> getOffset) <*> closing <*> arg <* string ">"
   when isClosing $ (openPos + 1) `failingWith'` NoOpeningCallbackTag oname
@@ -127,19 +128,19 @@ callback = do
     where children n = do
             eom <- asks endOfInput
             nodes <- nodesTill (lookAhead $ void (string "</") <|> eom)
-            pure . flip (Callback n) Fin $ nodes
+            pure . Callback n $ nodes
           closing = fmap isJust . hidden . optional . char $ '/'
 
-interp :: Parser Node
+interp :: Parser (Node -> Node)
 interp = between (char '{') (char '}') $ do
   n <- arg
-  option (String n Fin) (sep *> body n)
+  option (String n) (sep *> body n)
   where sep = string "," <* hspace1
         body n = choice
-          [ (\(t, f) -> Bool n t f Fin) <$> (string "boolean" *> sep *> boolCases)
-          , Number n Fin <$ string "number"
-          , flip (Date n) Fin <$> (string "date" *> sep *> dateTimeFmt)
-          , flip (Time n) Fin <$> (string "time" *> sep *> dateTimeFmt)
+          [ uncurry (Bool n) <$> (string "boolean" *> sep *> boolCases)
+          , Number n <$ string "number"
+          , Date n <$> (string "date" *> sep *> dateTimeFmt)
+          , Time n <$> (string "time" *> sep *> dateTimeFmt)
           , withPluralCtx n $ choice
               [ string "plural"        *> sep *> cardinalCases n
               , string "selectordinal" *> sep *> ordinalCases n
@@ -165,31 +166,31 @@ boolCases = (,)
    <* hspace1
   <*> (string "false" *> hspace1 *> caseBody)
 
-selectCases :: Arg -> Parser Node
+selectCases :: Arg -> Parser (Node -> Node)
 selectCases n = choice
   [ reconcile <$> cases <*> optional wildcard
-  , flip (SelectWild n) Fin <$> wildcard
+  , SelectWild n <$> wildcard
   ]
   where cases = NE.sepEndBy1 ((,) <$> (name <* hspace1) <*> caseBody) hspace1
         wildcard = string wildcardName *> hspace1 *> caseBody
-        reconcile cs (Just w) = SelectNamedWild n cs w Fin
-        reconcile cs Nothing  = SelectNamed n cs Fin
+        reconcile cs (Just w) = SelectNamedWild n cs w
+        reconcile cs Nothing  = SelectNamed n cs
         name = try $ mfilter (/= wildcardName) ident
         wildcardName = "other"
 
-cardinalCases :: Arg -> Parser Node
+cardinalCases :: Arg -> Parser (Node -> Node)
 cardinalCases n = try (cardinalInexactCases n) <|> cardinalExactCases n
 
-cardinalExactCases :: Arg -> Parser Node
-cardinalExactCases n = flip (CardinalExact n) Fin <$> NE.sepEndBy1 pluralExactCase hspace1
+cardinalExactCases :: Arg -> Parser (Node -> Node)
+cardinalExactCases n = CardinalExact n <$> NE.sepEndBy1 pluralExactCase hspace1
 
-cardinalInexactCases :: Arg -> Parser Node
+cardinalInexactCases :: Arg -> Parser (Node -> Node)
 cardinalInexactCases n = uncurry f <$> mixedPluralCases <*> pluralWildcard
-  where f e r w = CardinalInexact n e r w Fin
+  where f e r w = CardinalInexact n e r w
 
-ordinalCases :: Arg -> Parser Node
+ordinalCases :: Arg -> Parser (Node -> Node)
 ordinalCases n = uncurry f <$> mixedPluralCases <*> pluralWildcard
-  where f e r w = Ordinal n e r w Fin
+  where f e r w = Ordinal n e r w
 
 mixedPluralCases :: Parser ([PluralCase PluralExact], [PluralCase PluralRule])
 mixedPluralCases = partitionEithers <$> sepEndBy (eitherP pluralExactCase pluralRuleCase) hspace1

--- a/lib/Intlc/Parser/ICU.hs
+++ b/lib/Intlc/Parser/ICU.hs
@@ -1,3 +1,12 @@
+-- Parse an ICU message with annotations/source offsets. These annotations can
+-- be stripped later externally if unwanted.
+--
+-- Most parsers parse for functions. This might seem counterintuitive, but it's
+-- to match the shape of our AST in which, like a singly-linked list, each node
+-- points to its next sibling. Equivalently a `Parser (a -> NodeF a)` is
+-- typically a parser which has parsed all but the following sibling. A simple
+-- example of this would be `pure (CharF 'a')`.
+--
 -- This module follows the following whitespace rules:
 --   * Consume all whitespace after nodes where possible.
 --   * Therefore, assume no whitespace before nodes.
@@ -5,6 +14,8 @@
 module Intlc.Parser.ICU where
 
 import qualified Control.Applicative.Combinators.NonEmpty as NE
+import           Control.Comonad.Cofree                   (Cofree ((:<)),
+                                                           unwrap)
 import qualified Data.Text                                as T
 import           Data.Void                                ()
 import           Intlc.ICU
@@ -35,37 +46,42 @@ emptyState = ParserState
 
 type Parser = ReaderT ParserState (Parsec ParseErr Text)
 
+-- | Lifts the contents of the parser to contain annotations at this layer of
+-- the `Cofree`.
+withAnn :: Parser (AnnNode -> NodeF AnnNode) -> Parser (AnnNode -> AnnNode)
+withAnn p = (\i f z -> i :< f z) <$> getOffset <*> p
+
 ident :: Parser Text
 ident = label "alphabetic identifier" $ T.pack <$> some letterChar
 
 arg :: Parser Arg
 arg = Arg <$> ident
 
--- | Parse a message until end of input.
+-- | Parse a message with annotations until end of input.
 --
 -- To instead parse a message as part of a broader data structure, instead look
 -- at `msg` and its `endOfInput` state property.
-msg' :: Parsec ParseErr Text Message
-msg' = runReaderT msg cfg where
+annMsg' :: Parsec ParseErr Text AnnMessage
+annMsg' = runReaderT annMsg cfg where
   cfg = emptyState { endOfInput = eof }
 
--- Parse a message until the end of input parser matches.
-msg :: Parser Message
-msg = msgTill =<< asks endOfInput
+-- Parse a message with annotations until the end of input parser matches.
+annMsg :: Parser AnnMessage
+annMsg = annMsgTill =<< asks endOfInput
 
--- Parse a message until the provided parser matches.
-msgTill :: Parser a -> Parser Message
-msgTill = fmap Message . nodesTill
+-- Parse a message with annotations until the provided parser matches.
+annMsgTill :: Parser a -> Parser AnnMessage
+annMsgTill = fmap AnnMessage . nodesTill
 
--- Parse as many `Node`s as possible until the provided parser matches.
-nodesTill :: Parser a -> Parser Node
+nodesTill :: Parser a -> Parser AnnNode
 nodesTill end = go where
-  go = (Fin <$ end) <|> (node <*> go)
+  go = fin <|> (withAnn node <*> go)
+  fin = (:< FinF) <$> (getOffset <* end)
 
 -- The core parser of this module. Parse as many of these as you'd like until
 -- reaching an anticipated delimiter, such as a double quote in the surrounding
 -- JSON string or end of input in a REPL.
-node :: Parser (Node -> Node)
+node :: Parser (AnnNode -> NodeF AnnNode)
 node = choice
   [ interp
   , callback
@@ -73,41 +89,41 @@ node = choice
   -- `#`. When there's no such context, fail the parse in effect treating it
   -- as plaintext.
   , asks pluralCtxName >>= \case
-      Just n  -> PluralRef n <$ string "#"
+      Just n  -> PluralRefF n <$ string "#"
       Nothing -> empty
   , plaintext
   ]
 
 -- Parse a character or a potentially larger escape sequence.
-plaintext :: Parser (Node -> Node)
+plaintext :: Parser (AnnNode -> NodeF AnnNode)
 plaintext = choice
   [ try escaped
-  , Char <$> L.charLiteral
+  , CharF <$> L.charLiteral
   ]
 
 -- Follows ICU 4.8+ spec, see:
 --   https://unicode-org.github.io/icu/userguide/format_parse/messages/#quotingescaping
-escaped :: Parser (Node -> Node)
+escaped :: Parser (AnnNode -> NodeF AnnNode)
 escaped = apos *> choice
   -- Double escape two apostrophes as one, regardless of surrounding
   -- syntax: "''" -> "'"
-  [ Char <$> apos
+  [ CharF <$> apos
   -- Escape everything until another apostrophe, being careful of internal
   -- double escapes: "'{a''}'" -> "{a'}". Must ensure it doesn't surpass the
   -- bounds of the surrounding parser as per `endOfInput`.
   , try $ do
       eom <- asks endOfInput
-      head' <- Char <$> synOpen
+      head' <- withAnn (CharF <$> synOpen)
       -- Try and parse until end of input or a lone apostrophe. If end of input
       -- comes first then fail the parse.
-      (tail', wasEom) <- someTill_ plaintext $ choice
+      (tail', wasEom) <- someTill_ (withAnn plaintext) $ choice
         [       True  <$ eom
         , try $ False <$ apos <* notFollowedBy apos
         ]
       guard (not wasEom)
-      pure . foldr (.) id $ head' : tail'
+      pure $ unwrap . foldr (.) id (head' : tail')
   -- Escape the next syntax character as plaintext: "'{" -> "{"
-  , Char <$> synAll
+  , CharF <$> synAll
   ]
   where apos = char '\''
         synAll = synLone <|> synOpen <|> synClose
@@ -115,7 +131,7 @@ escaped = apos *> choice
         synOpen = char '{' <|> char '<'
         synClose = char '}' <|> char '>'
 
-callback :: Parser (Node -> Node)
+callback :: Parser (AnnNode -> NodeF AnnNode)
 callback = do
   (openPos, isClosing, oname) <- (,,) <$> (string "<" *> getOffset) <*> closing <*> arg <* string ">"
   when isClosing $ (openPos + 1) `failingWith'` NoOpeningCallbackTag oname
@@ -128,19 +144,19 @@ callback = do
     where children n = do
             eom <- asks endOfInput
             nodes <- nodesTill (lookAhead $ void (string "</") <|> eom)
-            pure . Callback n $ nodes
+            pure . CallbackF n $ nodes
           closing = fmap isJust . hidden . optional . char $ '/'
 
-interp :: Parser (Node -> Node)
+interp :: Parser (AnnNode -> NodeF AnnNode)
 interp = between (char '{') (char '}') $ do
   n <- arg
-  option (String n) (sep *> body n)
+  option (StringF n) (sep *> body n)
   where sep = string "," <* hspace1
         body n = choice
-          [ uncurry (Bool n) <$> (string "boolean" *> sep *> boolCases)
-          , Number n <$ string "number"
-          , Date n <$> (string "date" *> sep *> dateTimeFmt)
-          , Time n <$> (string "time" *> sep *> dateTimeFmt)
+          [ uncurry (BoolF n) <$> (string "boolean" *> sep *> boolCases)
+          , NumberF n <$ string "number"
+          , DateF n <$> (string "date" *> sep *> dateTimeFmt)
+          , TimeF n <$> (string "time" *> sep *> dateTimeFmt)
           , withPluralCtx n $ choice
               [ string "plural"        *> sep *> cardinalCases n
               , string "selectordinal" *> sep *> ordinalCases n
@@ -157,49 +173,47 @@ dateTimeFmt = choice
   , Full   <$ string "full"
   ]
 
-caseBody :: Parser Node
+caseBody :: Parser AnnNode
 caseBody = string "{" *> nodesTill (string "}")
 
-boolCases :: Parser (Node, Node)
+boolCases :: Parser (AnnNode, AnnNode)
 boolCases = (,)
   <$> (string "true"  *> hspace1 *> caseBody)
    <* hspace1
   <*> (string "false" *> hspace1 *> caseBody)
 
-selectCases :: Arg -> Parser (Node -> Node)
+selectCases :: Arg -> Parser (AnnNode -> NodeF AnnNode)
 selectCases n = choice
   [ reconcile <$> cases <*> optional wildcard
-  , SelectWild n <$> wildcard
+  , SelectWildF n <$> wildcard
   ]
   where cases = NE.sepEndBy1 ((,) <$> (name <* hspace1) <*> caseBody) hspace1
         wildcard = string wildcardName *> hspace1 *> caseBody
-        reconcile cs (Just w) = SelectNamedWild n cs w
-        reconcile cs Nothing  = SelectNamed n cs
+        reconcile cs (Just w) = SelectNamedWildF n cs w
+        reconcile cs Nothing  = SelectNamedF n cs
         name = try $ mfilter (/= wildcardName) ident
         wildcardName = "other"
 
-cardinalCases :: Arg -> Parser (Node -> Node)
+cardinalCases :: Arg -> Parser (AnnNode -> NodeF AnnNode)
 cardinalCases n = try (cardinalInexactCases n) <|> cardinalExactCases n
 
-cardinalExactCases :: Arg -> Parser (Node -> Node)
-cardinalExactCases n = CardinalExact n <$> NE.sepEndBy1 pluralExactCase hspace1
+cardinalExactCases :: Arg -> Parser (AnnNode -> NodeF AnnNode)
+cardinalExactCases n = CardinalExactF n <$> NE.sepEndBy1 pluralExactCase hspace1
 
-cardinalInexactCases :: Arg -> Parser (Node -> Node)
-cardinalInexactCases n = uncurry f <$> mixedPluralCases <*> pluralWildcard
-  where f e r w = CardinalInexact n e r w
+cardinalInexactCases :: Arg -> Parser (AnnNode -> NodeF AnnNode)
+cardinalInexactCases n = uncurry (CardinalInexactF n) <$> mixedPluralCases <*> pluralWildcard
 
-ordinalCases :: Arg -> Parser (Node -> Node)
-ordinalCases n = uncurry f <$> mixedPluralCases <*> pluralWildcard
-  where f e r w = Ordinal n e r w
+ordinalCases :: Arg -> Parser (AnnNode -> NodeF AnnNode)
+ordinalCases n = uncurry (OrdinalF n) <$> mixedPluralCases <*> pluralWildcard
 
-mixedPluralCases :: Parser ([PluralCase PluralExact], [PluralCase PluralRule])
+mixedPluralCases :: Parser ([PluralCaseF PluralExact AnnNode], [PluralCaseF PluralRule AnnNode])
 mixedPluralCases = partitionEithers <$> sepEndBy (eitherP pluralExactCase pluralRuleCase) hspace1
 
-pluralExactCase :: Parser (PluralCase PluralExact)
+pluralExactCase :: Parser (PluralCaseF PluralExact AnnNode)
 pluralExactCase = (,) <$> pluralExact <* hspace1 <*> caseBody
   where pluralExact = PluralExact . T.pack <$> (string "=" *> some numberChar)
 
-pluralRuleCase :: Parser (PluralCase PluralRule)
+pluralRuleCase :: Parser (PluralCaseF PluralRule AnnNode)
 pluralRuleCase = (,) <$> pluralRule <* hspace1 <*> caseBody
 
 pluralRule :: Parser PluralRule
@@ -211,5 +225,5 @@ pluralRule = choice
   , Many <$ string "many"
   ]
 
-pluralWildcard :: Parser Node
+pluralWildcard :: Parser AnnNode
 pluralWildcard = string "other" *> hspace1 *> caseBody

--- a/lib/Intlc/Parser/JSON.hs
+++ b/lib/Intlc/Parser/JSON.hs
@@ -35,7 +35,7 @@ data ParserState = ParserState
 failingWith' :: MonadParsec ParseErr s m => Int -> JSONParseErr -> m a
 i `failingWith'` e = i `failingWith` FailedJSONParse e
 
-dataset :: Parser (Dataset Translation)
+dataset :: Parser (Dataset AnnTranslation)
 dataset = space *> objMap translation <* space <* eof
 
 -- It's important to use `toPermutationWithDefault` as opposed to standard
@@ -45,15 +45,15 @@ dataset = space *> objMap translation <* space <* eof
 -- Additionally, the consistent application of whitespace is extremely
 -- important, and the permutation appears to operate over the first parser, so
 -- be careful around any abstractions around the key double quotes.
-translation :: Parser Translation
-translation = obj $ intercalateEffect objSep $ Translation
+translation :: Parser AnnTranslation
+translation = obj $ intercalateEffect objSep $ AnnTranslation
   <$> toPermutation                       (objPair' "message"     msg)
   <*> toPermutationWithDefault TypeScript (objPair' "backend"     (backendp <|> TypeScript <$ null))
   <*> toPermutationWithDefault Nothing    (objPair' "description" (Just <$> strLit <|> Nothing <$ null))
 
-msg :: Parser ICU.Message
+msg :: Parser ICU.AnnMessage
 msg = lift $ withRecovery recover p
-  where p = runReaderT (char '"' *> ICUP.msg) icupState
+  where p = runReaderT (char '"' *> ICUP.annMsg) icupState
         icupState = ICUP.emptyState { ICUP.endOfInput = void $ char '"' }
         recover e = error "absurd" <$ consume <* registerParseError e
         -- Once we've recovered we need to consume the rest of the message

--- a/lib/Intlc/Parser/JSON.hs
+++ b/lib/Intlc/Parser/JSON.hs
@@ -35,7 +35,7 @@ data ParserState = ParserState
 failingWith' :: MonadParsec ParseErr s m => Int -> JSONParseErr -> m a
 i `failingWith'` e = i `failingWith` FailedJSONParse e
 
-dataset :: Parser (Dataset AnnTranslation)
+dataset :: Parser (Dataset (Translation ICU.AnnMessage))
 dataset = space *> objMap translation <* space <* eof
 
 -- It's important to use `toPermutationWithDefault` as opposed to standard
@@ -45,8 +45,8 @@ dataset = space *> objMap translation <* space <* eof
 -- Additionally, the consistent application of whitespace is extremely
 -- important, and the permutation appears to operate over the first parser, so
 -- be careful around any abstractions around the key double quotes.
-translation :: Parser AnnTranslation
-translation = obj $ intercalateEffect objSep $ AnnTranslation
+translation :: Parser (Translation ICU.AnnMessage)
+translation = obj $ intercalateEffect objSep $ Translation
   <$> toPermutation                       (objPair' "message"     msg)
   <*> toPermutationWithDefault TypeScript (objPair' "backend"     (backendp <|> TypeScript <$ null))
   <*> toPermutationWithDefault Nothing    (objPair' "description" (Just <$> strLit <|> Nothing <$ null))

--- a/test/Intlc/EndToEndSpec.hs
+++ b/test/Intlc/EndToEndSpec.hs
@@ -4,11 +4,12 @@ import qualified Data.Text                  as T
 import           Intlc.Backend.ICU.Compiler (Formatting (SingleLine),
                                              compileMsg)
 import           Intlc.Compiler             (compileDataset, expandPlurals)
-import           Intlc.Core                 (Locale (Locale))
+import           Intlc.Core                 (Locale (Locale), datasetSansAnn)
+import           Intlc.ICU                  (sansAnnMsg)
 import           Intlc.Parser               (parseDataset)
 import           Intlc.Parser.Error         (ParseFailure)
-import           Intlc.Parser.ICU           (ParserState (endOfInput),
-                                             emptyState, msg)
+import           Intlc.Parser.ICU           (ParserState (endOfInput), annMsg,
+                                             emptyState)
 import           Prelude
 import           System.FilePath            ((<.>), (</>))
 import           Test.Hspec
@@ -17,11 +18,11 @@ import           Text.Megaparsec            (eof, runParser)
 import           Text.RawString.QQ          (r)
 
 parseAndCompileDataset :: Text -> Either (NonEmpty Text) Text
-parseAndCompileDataset = compileDataset (Locale "en-US") <=< first (pure . show) . parseDataset "test"
+parseAndCompileDataset = compileDataset (Locale "en-US") . datasetSansAnn <=< first (pure . show) . parseDataset "test"
 
 parseAndExpandMsg :: Text -> Either ParseFailure Text
-parseAndExpandMsg = fmap (compileMsg SingleLine . expandPlurals) . parseMsg
-  where parseMsg = runParser (runReaderT msg (emptyState { endOfInput = eof })) "test"
+parseAndExpandMsg = fmap (compileMsg SingleLine . expandPlurals . sansAnnMsg) . parseMsg
+  where parseMsg = runParser (runReaderT annMsg (emptyState { endOfInput = eof })) "test"
 
 golden :: String -> Text -> Golden String
 golden name in' = baseCfg

--- a/test/Intlc/LinterSpec.hs
+++ b/test/Intlc/LinterSpec.hs
@@ -13,7 +13,7 @@ withAnn = AnnMessage . cata (0 :<) . unMessage
 
 lintWith' :: Rule (WithAnn a) -> Message -> Status a
 lintWith' r = statusSansAnn . lintWith (pure r) . withAnn where
-  statusSansAnn Success = Success
+  statusSansAnn Success      = Success
   statusSansAnn (Failure xs) = Failure (snd <$> xs)
 
 spec :: Spec

--- a/test/Intlc/LinterSpec.hs
+++ b/test/Intlc/LinterSpec.hs
@@ -1,12 +1,20 @@
 module Intlc.LinterSpec where
 
+import           Control.Comonad.Cofree (Cofree ((:<)))
+import           Data.Functor.Foldable  (cata)
 import           Intlc.ICU
 import           Intlc.Linter
 import           Prelude
 import           Test.Hspec
 
-lintWith' :: Rule a -> Message -> Status a
-lintWith' = lintWith . pure
+-- | Annotate an AST with nonsense. We won't test the annotations.
+withAnn :: Message -> AnnMessage
+withAnn = AnnMessage . cata (0 :<) . unMessage
+
+lintWith' :: Rule (WithAnn a) -> Message -> Status a
+lintWith' r = statusSansAnn . lintWith (pure r) . withAnn where
+  statusSansAnn Success = Success
+  statusSansAnn (Failure xs) = Failure (snd <$> xs)
 
 spec :: Spec
 spec = describe "linter" $ do

--- a/test/Intlc/Parser/ICUSpec.hs
+++ b/test/Intlc/Parser/ICUSpec.hs
@@ -1,20 +1,47 @@
 module Intlc.Parser.ICUSpec (spec) where
 
+import           Control.Comonad.Cofree (Cofree ((:<)))
 import           Intlc.ICU
-import           Intlc.Parser.Error    (MessageParseErr (..),
-                                        ParseErr (FailedMsgParse), ParseFailure)
+import           Intlc.Parser.Error     (MessageParseErr (..),
+                                         ParseErr (FailedMsgParse),
+                                         ParseFailure)
 import           Intlc.Parser.ICU
 import           Prelude
 import           Test.Hspec
 import           Test.Hspec.Megaparsec
-import           Text.Megaparsec       (eof, runParser)
-import           Text.Megaparsec.Error (ErrorFancy (ErrorCustom))
+import           Text.Megaparsec        (eof, runParser)
+import           Text.Megaparsec.Error  (ErrorFancy (ErrorCustom))
 
-parseWith :: ParserState -> Parser a -> Text -> Either ParseFailure a
-parseWith s p = runParser (runReaderT p s) "test"
+-- | Offset parsing won't generally be tested in this module as it just adds
+-- noise.
+--
+-- Most of our parsers return functions awaiting their next sibling. This ties
+-- that knot with a nonsense offset.
+nonsenseAnn :: NodeF AnnNode -> AnnNode
+nonsenseAnn = (-1 :<)
+
+sansAnn' :: NodeF AnnNode -> Node
+sansAnn' = sansAnn . nonsenseAnn
+
+fin :: AnnNode
+fin = nonsenseAnn FinF
+
+runParserWith :: ParserState -> Parser a -> Text -> Either ParseFailure a
+runParserWith s p = runParser (runReaderT p s) "test"
+
+parseWith :: ParserState -> Parser (NodeF AnnNode) -> Text -> Either ParseFailure Node
+parseWith s p = runParserWith s (sansAnn' <$> p)
 
 parse :: Parser a -> Text -> Either ParseFailure a
-parse = parseWith $ emptyState { endOfInput = eof }
+parse = runParserWith $ emptyState { endOfInput = eof }
+
+parseF :: Parser (AnnNode -> NodeF AnnNode) -> Text -> Either ParseFailure Node
+-- The most satisfying line of code I've ever written:
+parseF = parse . fmap sansAnn' . flip flap fin
+
+-- | Message parser sans annotations.
+msg :: Parser Message
+msg = sansAnnMsg <$> annMsg
 
 spec :: Spec
 spec = describe "ICU parser" $ do
@@ -87,15 +114,32 @@ spec = describe "ICU parser" $ do
         parse msg "' '" `shouldParse` Message "' '"
         parse msg "x'y" `shouldParse` Message "x'y"
 
-  describe "interpolation" $ do
-    let interp' = interp ?? Fin
+    -- As you can see this isn't fun to write out by hand for tests. This one
+    -- test can suffice for ensuring we're parsing annotations correctly.
+    it "parses with annotations" $ do
+      parse annMsg "Hello' {n, plural, one {{name}} other {}}!" `shouldParse` AnnMessage
+        ( 0 :< CharF 'H' (
+          1 :< CharF 'e' (
+          2 :< CharF 'l' (
+          3 :< CharF 'l' (
+          4 :< CharF 'o' (
+          5 :< CharF '\'' (
+          6 :< CharF ' ' (
+          7 :< CardinalInexactF "n"
+            mempty
+            (pure (One, 24 :< StringF "name" (30 :< FinF)))
+            (39 :< FinF) (
+          41 :< CharF '!' (
+          42 :< FinF
+        ))))))))))
 
+  describe "interpolation" $ do
     it "interpolates appropriately" $ do
-      parse interp' "{x}" `shouldParse` String' "x"
+      parseF interp "{x}" `shouldParse` String' "x"
 
     it "only accepts alphanumeric identifiers" $ do
-      parse interp' "{XyZ}" `shouldParse` String' "XyZ"
-      parse interp' `shouldFailOn` "{x y}"
+      parseF interp "{XyZ}" `shouldParse` String' "XyZ"
+      parseF interp `shouldFailOn` "{x y}"
 
     it "disallows bad types" $ do
       parse msg `shouldFailOn` "{n, enum}"
@@ -103,104 +147,103 @@ spec = describe "ICU parser" $ do
 
     describe "bool" $ do
       it "requires both bool cases" $ do
-        parse interp' "{x, boolean, true {y} false {z}}" `shouldParse` Bool' "x" "y" "z"
-        parse interp' `shouldFailOn` "{x, boolean, true {y}}"
-        parse interp' `shouldFailOn` "{x, boolean, false {y}}"
+        parseF interp "{x, boolean, true {y} false {z}}" `shouldParse` Bool' "x" "y" "z"
+        parseF interp `shouldFailOn` "{x, boolean, true {y}}"
+        parseF interp `shouldFailOn` "{x, boolean, false {y}}"
 
       it "enforces case order" $ do
-        parse interp' `shouldFailOn` "{x, boolean, false {y} true {z}}"
+        parseF interp `shouldFailOn` "{x, boolean, false {y} true {z}}"
 
       it "disallows arbitrary cases" $ do
-        parse interp' `shouldFailOn` "{x, boolean, true {y} nottrue {z}}"
+        parseF interp `shouldFailOn` "{x, boolean, true {y} nottrue {z}}"
 
     describe "date" $ do
       it "disallows bad formats" $ do
-        parse interp' "{x, date, short}" `shouldParse` Date' "x" Short
-        parse interp' `shouldFailOn` "{x, date, miniature}"
+        parseF interp "{x, date, short}" `shouldParse` Date' "x" Short
+        parseF interp `shouldFailOn` "{x, date, miniature}"
 
     describe "time" $ do
       it "disallows bad formats" $ do
-        parse interp' "{x, time, short}" `shouldParse` Time' "x" Short
-        parse interp' `shouldFailOn` "{x, time, miniature}"
+        parseF interp "{x, time, short}" `shouldParse` Time' "x" Short
+        parseF interp `shouldFailOn` "{x, time, miniature}"
 
   describe "callback" $ do
-    let callback' = callback ?? Fin
     let e i = errFancy i . fancy . ErrorCustom . FailedMsgParse
 
     it "parses nested" $ do
-      parse callback' "<f><g>x{y}z</g></f>" `shouldParse`
+      parseF callback "<f><g>x{y}z</g></f>" `shouldParse`
         Callback' "f" (Callback' "g" (mconcat ["x", String' "y", "z"]))
 
     it "requires closing tag" $ do
-      parse callback' "<hello> there" `shouldFailWith` e 1 (NoClosingCallbackTag "hello")
+      parseF callback "<hello> there" `shouldFailWith` e 1 (NoClosingCallbackTag "hello")
 
     it "requires opening tag" $ do
-      parse callback' "</hello> <there>" `shouldFailWith` e 2 (NoOpeningCallbackTag "hello")
+      parseF callback "</hello> <there>" `shouldFailWith` e 2 (NoOpeningCallbackTag "hello")
 
     it "validates closing tag name" $ do
-      parse callback' "<hello></hello>" `shouldParse` Callback' "hello" mempty
-      parse callback' "<hello></there>" `shouldFailWith` e 9 (BadClosingCallbackTag "hello" "there")
+      parseF callback "<hello></hello>" `shouldParse` Callback' "hello" mempty
+      parseF callback "<hello></there>" `shouldFailWith` e 9 (BadClosingCallbackTag "hello" "there")
 
     it "only accepts alphanumeric identifiers" $ do
-      parse callback' "<XyZ></XyZ>" `shouldParse` Callback' "XyZ" mempty
-      parse callback' `shouldFailOn` "<x y></x y>"
+      parseF callback "<XyZ></XyZ>" `shouldParse` Callback' "XyZ" mempty
+      parseF callback `shouldFailOn` "<x y></x y>"
 
   describe "plural" $ do
-    let cardinalCases' = cardinalCases "arg" <* eof ?? Fin
+    let cardinalCases' = cardinalCases "arg" <* eof
 
     it "disallows wildcard not at the end" $ do
-      parse cardinalCases' `shouldSucceedOn` "=1 {foo} other {bar}"
-      parse cardinalCases' `shouldFailOn` "other {bar} =1 {foo}"
+      parseF cardinalCases' `shouldSucceedOn` "=1 {foo} other {bar}"
+      parseF cardinalCases' `shouldFailOn` "other {bar} =1 {foo}"
 
     it "tolerates empty cases" $ do
-      parse cardinalCases' `shouldSucceedOn` "=1 {} other {}"
+      parseF cardinalCases' `shouldSucceedOn` "=1 {} other {}"
 
     it "tolerates no non-wildcard cases" $ do
-      parse cardinalCases' `shouldSucceedOn` "other {foo}"
+      parseF cardinalCases' `shouldSucceedOn` "other {foo}"
 
     it "requires a wildcard if there are any rule cases" $ do
-      parse cardinalCases' `shouldFailOn`    "=0 {foo} one {bar}"
-      parse cardinalCases' `shouldSucceedOn` "=0 {foo} one {bar} other {baz}"
-      parse cardinalCases' `shouldSucceedOn` "=0 {foo} =1 {bar}"
+      parseF cardinalCases' `shouldFailOn`    "=0 {foo} one {bar}"
+      parseF cardinalCases' `shouldSucceedOn` "=0 {foo} one {bar} other {baz}"
+      parseF cardinalCases' `shouldSucceedOn` "=0 {foo} =1 {bar}"
 
     it "parses literal and plural cases, wildcard, and interpolation node" $ do
-      parseWith (emptyState { pluralCtxName = Just "xyz" }) cardinalCases' "=0 {foo} few {bar} other {baz #}" `shouldParse`
+      parseWith (emptyState { pluralCtxName = Just "xyz" }) (cardinalCases' ?? fin) "=0 {foo} few {bar} other {baz #}" `shouldParse`
         CardinalInexact' "arg" (pure (PluralExact "0", "foo")) (pure (Few, "bar")) (mconcat ["baz ", PluralRef' "xyz"])
 
   describe "selectordinal" $ do
-    let ordinalCases' = ordinalCases "arg" <* eof ?? Fin
+    let ordinalCases' = ordinalCases "arg" <* eof
 
     it "disallows wildcard not at the end" $ do
-      parse ordinalCases' `shouldSucceedOn` "one {foo} other {bar}"
-      parse ordinalCases' `shouldFailOn` "other {bar} one {foo}"
+      parseF ordinalCases' `shouldSucceedOn` "one {foo} other {bar}"
+      parseF ordinalCases' `shouldFailOn` "other {bar} one {foo}"
 
     it "tolerates empty cases" $ do
-      parse ordinalCases' `shouldSucceedOn` "one {} other {}"
+      parseF ordinalCases' `shouldSucceedOn` "one {} other {}"
 
     it "tolerates no non-wildcard cases" $ do
-      parse ordinalCases' `shouldSucceedOn` "other {foo}"
+      parseF ordinalCases' `shouldSucceedOn` "other {foo}"
 
     it "requires a wildcard" $ do
-      parse ordinalCases' `shouldFailOn`    "=0 {foo} one {bar}"
-      parse ordinalCases' `shouldSucceedOn` "=0 {foo} one {bar} other {baz}"
+      parseF ordinalCases' `shouldFailOn`    "=0 {foo} one {bar}"
+      parseF ordinalCases' `shouldSucceedOn` "=0 {foo} one {bar} other {baz}"
 
     it "parses literal and plural cases, wildcard, and interpolation node" $ do
-      parseWith (emptyState { pluralCtxName = Just "xyz" }) ordinalCases' "=0 {foo} few {bar} other {baz #}" `shouldParse`
+      parseWith (emptyState { pluralCtxName = Just "xyz" }) (ordinalCases' ?? fin) "=0 {foo} few {bar} other {baz #}" `shouldParse`
         Ordinal' "arg" (pure (PluralExact "0", "foo")) (pure (Few, "bar")) (mconcat ["baz ", PluralRef' "xyz"])
 
   describe "select" $ do
-    let selectCases' = selectCases "arg" <* eof ?? Fin
+    let selectCases' = selectCases "arg" <* eof
 
     it "disallows wildcard not at the end" $ do
-      parse selectCases' "foo {bar} other {baz}" `shouldParse`
+      parseF selectCases' "foo {bar} other {baz}" `shouldParse`
         SelectNamedWild' "arg" (pure ("foo", "bar")) "baz"
-      parse selectCases' `shouldFailOn` "other {bar} foo {baz}"
+      parseF selectCases' `shouldFailOn` "other {bar} foo {baz}"
 
     it "tolerates empty cases" $ do
-      parse selectCases' "x {} other {}" `shouldParse` SelectNamedWild' "arg" (pure ("x", mempty)) mempty
+      parseF selectCases' "x {} other {}" `shouldParse` SelectNamedWild' "arg" (pure ("x", mempty)) mempty
 
     it "allows no non-wildcard case" $ do
-      parse selectCases' "foo {bar}" `shouldParse` SelectNamed' "arg" (pure ("foo", "bar"))
-      parse selectCases' "foo {bar} other {baz}" `shouldParse`
+      parseF selectCases' "foo {bar}" `shouldParse` SelectNamed' "arg" (pure ("foo", "bar"))
+      parseF selectCases' "foo {bar} other {baz}" `shouldParse`
         SelectNamedWild' "arg" (pure ("foo", "bar")) "baz"
-      parse selectCases' "other {foo}" `shouldParse` SelectWild' "arg" "foo"
+      parseF selectCases' "other {foo}" `shouldParse` SelectWild' "arg" "foo"

--- a/test/Intlc/Parser/JSONSpec.hs
+++ b/test/Intlc/Parser/JSONSpec.hs
@@ -11,7 +11,7 @@ import           Test.Hspec.Megaparsec
 import           Text.Megaparsec       (ErrorFancy (ErrorCustom), ParseError)
 import           Text.RawString.QQ     (r)
 
-parse :: Text -> Either ParseFailure (Dataset Translation)
+parse :: Text -> Either ParseFailure (Dataset (Translation ICU.Message))
 parse = fmap datasetSansAnn . parseDataset "test"
 
 succeedsOn :: Text -> Expectation

--- a/test/Intlc/Parser/JSONSpec.hs
+++ b/test/Intlc/Parser/JSONSpec.hs
@@ -12,7 +12,7 @@ import           Text.Megaparsec       (ErrorFancy (ErrorCustom), ParseError)
 import           Text.RawString.QQ     (r)
 
 parse :: Text -> Either ParseFailure (Dataset Translation)
-parse = parseDataset "test"
+parse = fmap datasetSansAnn . parseDataset "test"
 
 succeedsOn :: Text -> Expectation
 succeedsOn = shouldSucceedOn parse


### PR DESCRIPTION
There's some further minor refactoring that could be done but this PR is already fairly big, particularly conceptually, and I'm really happy with where it's at as-is.

This PR adds a mechanism by which we can record AST source annotations/offsets during parsing for later use, and utilises them to drastically improve linting output. Closes #142.

Given:

```json
{
  "msg": {
    "message": "Some words {mySelect, select, other {}} {myCardinal, plural, =1 {} =1 {}}"
  }
}
```

Before:

```
msg: 
 Redundant select: mySelect
 Duplicate plural case: myCardinal, =1
```

With this PR:

```
translations.json:3:29:
  |
3 |     "message": "Some words {mySelect, select, other {}} {myCardinal, plural, =1 {} =1 {}}"
  |                             ^^^^^^^^
redundant-select: Select named `mySelect` is redundant as it only contains a wildcard.

Learn more: https://github.com/unsplash/intlc/wiki/Lint-rules-reference#redundant-select

translations.json:3:84:
  |
3 |     "message": "Some words {mySelect, select, other {}} {myCardinal, plural, =1 {} =1 {}}"
  |                                                                                    ^^
duplicate-plural-case: Plural named `myCardinal` contains a duplicate `=1` case.

Learn more: https://github.com/unsplash/intlc/wiki/Lint-rules-reference#duplicate-plural-case
```

A new wiki page is linked, closing #141: https://github.com/unsplash/intlc/wiki/Lint-rules-reference

Technically this PR piggybacks on the pattern functor introduced in #171, utilising [`Cofree`](https://hackage.haskell.org/package/free-5.1.9/docs/Control-Comonad-Cofree.html#t:Cofree) to compose each layer of the AST with an additional `Int` representing a source offset for pretty printing later. `Cofree` is simpler than it looks or sounds from the consumer perspective: what was once `FinF` is now for example `123 :< FinF`. What's particularly nice about this approach is that our core AST is untouched, leaving most of the code unaffected and leaving the door open for other compositions.

Additionally a couple of lint rules now make use of paramorphisms, which are like catamorphisms but give you access to the original data at each recursion layer as well. They do so in order to calculate where to place the pretty error carets.

I'm not intending to introduce any further abstract technical stuff after this, promise :angel: