### PR TITLE
Prettified JSON

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Hoist selectors up as much as possible. This is often preferred by translators.
 ```console
 $ cat translations.json
 {"openSource":{"message": "Open source at {company} is {company, select, Unsplash {encouraged!} other {unknown}}"}}
-$ intlc flatten translations.json
+$ intlc flatten --minify translations.json
 {"openSource":{"message":"{company, select, Unsplash {Open source at {company} is encouraged!} other {Open source at {company} is unknown}}"}}
 ```
 

--- a/cli/CLI.hs
+++ b/cli/CLI.hs
@@ -1,12 +1,13 @@
 module CLI (Opts (..), getOpts) where
 
-import           Intlc.Core          (Locale (..))
+import qualified Intlc.Backend.JSON.Compiler as JSON
+import           Intlc.Core                  (Locale (..))
 import           Options.Applicative
 import           Prelude
 
 data Opts
   = Compile FilePath Locale
-  | Flatten FilePath
+  | Flatten FilePath JSON.Formatting
   | Lint    FilePath
   | Prettify Text
 
@@ -26,7 +27,7 @@ compile :: Parser Opts
 compile = Compile <$> pathp <*> localep
 
 flatten :: Parser Opts
-flatten = Flatten <$> pathp
+flatten = Flatten <$> pathp <*> minifyp
 
 lint :: Parser Opts
 lint = Lint <$> pathp
@@ -39,6 +40,9 @@ pathp = argument str (metavar "filepath")
 
 localep :: Parser Locale
 localep = Locale <$> strOption (short 'l' <> long "locale")
+
+minifyp :: Parser JSON.Formatting
+minifyp = flag JSON.Pretty JSON.Minified (long "minify")
 
 prettify :: Parser Opts
 prettify = Prettify <$> msgp

--- a/cli/Main.hs
+++ b/cli/Main.hs
@@ -1,14 +1,16 @@
 module Main where
 
-import           CLI                (Opts (..), getOpts)
-import qualified Data.Text          as T
-import           Intlc.Compiler     (compileDataset, compileFlattened)
+import           CLI                         (Opts (..), getOpts)
+import qualified Data.Text                   as T
+import qualified Intlc.Backend.JSON.Compiler as JSON
+import           Intlc.Compiler              (compileDataset, compileFlattened)
 import           Intlc.Core
-import           Intlc.ICU          (AnnNode, Message, Node, sansAnn)
+import           Intlc.ICU                   (AnnNode, Message, Node, sansAnn)
 import           Intlc.Linter
-import           Intlc.Parser       (parseDataset, parseMessage, printErr)
-import           Intlc.Parser.Error (ParseFailure)
-import           Intlc.Prettify     (prettify)
+import           Intlc.Parser                (parseDataset, parseMessage,
+                                              printErr)
+import           Intlc.Parser.Error          (ParseFailure)
+import           Intlc.Prettify              (prettify)
 import           Prelude
 
 main :: IO ()
@@ -24,7 +26,7 @@ compile loc = compileDataset loc >>> \case
   Right x -> putTextLn x
 
 flatten :: MonadIO m => Dataset (Translation (Message Node)) -> m ()
-flatten = putTextLn . compileFlattened
+flatten = putTextLn . compileFlattened JSON.Minified
 
 lint :: MonadIO m => FilePath -> m ()
 lint path = do

--- a/cli/Main.hs
+++ b/cli/Main.hs
@@ -16,7 +16,7 @@ import           Prelude
 main :: IO ()
 main = getOpts >>= \case
   Compile path loc -> tryGetParsedAtSansAnn path >>= compile loc
-  Flatten path     -> tryGetParsedAtSansAnn path >>= flatten
+  Flatten path fo  -> tryGetParsedAtSansAnn path >>= flatten fo
   Lint    path     -> lint path
   Prettify msg     -> tryPrettify msg
 
@@ -25,8 +25,8 @@ compile loc = compileDataset loc >>> \case
   Left es -> die . T.unpack . ("Invalid keys:\n" <>) . T.intercalate "\n" . fmap ("\t" <>) . toList $ es
   Right x -> putTextLn x
 
-flatten :: MonadIO m => Dataset (Translation (Message Node)) -> m ()
-flatten = putTextLn . compileFlattened JSON.Minified
+flatten :: MonadIO m => JSON.Formatting -> Dataset (Translation (Message Node)) -> m ()
+flatten fo = putTextLn . compileFlattened fo
 
 lint :: MonadIO m => FilePath -> m ()
 lint path = do

--- a/internal/CLI.hs
+++ b/internal/CLI.hs
@@ -1,12 +1,13 @@
 module CLI (Opts (..), getOpts) where
 
+import qualified Intlc.Backend.JSON.Compiler as JSON
 import           Options.Applicative
 import           Prelude
 
 data Opts
   = Lint FilePath
   -- Takes stdin.
-  | ExpandPlurals
+  | ExpandPlurals JSON.Formatting
 
 getOpts :: IO Opts
 getOpts = execParser (info (opts <**> helper) (progDesc h))
@@ -22,7 +23,10 @@ lint :: Parser Opts
 lint = Lint <$> pathp
 
 expandPlurals :: Parser Opts
-expandPlurals = pure ExpandPlurals
+expandPlurals = ExpandPlurals <$> minifyp
 
 pathp :: Parser FilePath
 pathp = argument str (metavar "filepath")
+
+minifyp :: Parser JSON.Formatting
+minifyp = flag JSON.Pretty JSON.Minified (long "minify")

--- a/internal/Main.hs
+++ b/internal/Main.hs
@@ -3,7 +3,7 @@ module Main where
 import           CLI                         (Opts (..), getOpts)
 import qualified Data.Text                   as T
 import           Data.Text.IO                (getContents)
-import           Intlc.Backend.JSON.Compiler (compileDataset)
+import qualified Intlc.Backend.JSON.Compiler as JSON
 import           Intlc.Compiler              (expandPlurals)
 import           Intlc.Core
 import           Intlc.ICU                   (AnnNode, Message, Node)
@@ -24,7 +24,8 @@ lint path = do
   whenJust (lintDatasetInternal path raw dataset) $ die . T.unpack
 
 compileExpandedPlurals :: MonadIO m => Dataset (Translation (Message Node)) -> m ()
-compileExpandedPlurals = putTextLn . compileDataset . fmap (\x -> x { message = expandPlurals x.message })
+compileExpandedPlurals = putTextLn . JSON.compileDataset JSON.Minified . fmap f
+  where f x = x { message = expandPlurals x.message }
 
 tryGetParsedStdinSansAnn :: IO (Dataset (Translation (Message Node)))
 tryGetParsedStdinSansAnn = parserDie . fmap datasetSansAnn =<< getParsedStdin

--- a/internal/Main.hs
+++ b/internal/Main.hs
@@ -14,8 +14,8 @@ import           Prelude                     hiding (filter)
 
 main :: IO ()
 main = getOpts >>= \case
-  Lint path     -> lint path
-  ExpandPlurals -> tryGetParsedStdinSansAnn >>= compileExpandedPlurals
+  Lint path        -> lint path
+  ExpandPlurals fo -> tryGetParsedStdinSansAnn >>= compileExpandedPlurals fo
 
 lint :: MonadIO m => FilePath -> m ()
 lint path = do
@@ -23,8 +23,8 @@ lint path = do
   dataset <- parserDie $ parseDataset path raw
   whenJust (lintDatasetInternal path raw dataset) $ die . T.unpack
 
-compileExpandedPlurals :: MonadIO m => Dataset (Translation (Message Node)) -> m ()
-compileExpandedPlurals = putTextLn . JSON.compileDataset JSON.Minified . fmap f
+compileExpandedPlurals :: MonadIO m => JSON.Formatting -> Dataset (Translation (Message Node)) -> m ()
+compileExpandedPlurals fo = putTextLn . JSON.compileDataset fo . fmap f
   where f x = x { message = expandPlurals x.message }
 
 tryGetParsedStdinSansAnn :: IO (Dataset (Translation (Message Node)))

--- a/lib/Intlc/Backend/JSON/Compiler.hs
+++ b/lib/Intlc/Backend/JSON/Compiler.hs
@@ -45,13 +45,13 @@ obj :: Compiler [(Text, Text)] -> Compiler Text
 obj xs = asks fmt >>= \case
   Minified -> do
     let objPair k v = objKey k <> ":" <> v
-    contents <- fmap (T.intercalate "," . fmap (uncurry objPair)) $ xs
+    contents <- T.intercalate "," . fmap (uncurry objPair) <$> xs
     pure $ "{" <> contents <> "}"
   Pretty   -> do
     i <- asks indentLevels
-    let objPair k v = (indentBy (i + 1) <>) $ objKey k <> ": " <> v
-    contents <- fmap (T.intercalate ("," <> newline) . fmap (uncurry objPair)) . increment $ xs
-    pure $ "{" <> newline <> contents <> newline <> indentBy i <> "}"
+    let objPair k v = newline <> indentBy (i + 1) <> objKey k <> ": " <> v
+    contents <- fmap (T.intercalate "," . fmap (uncurry objPair)) . increment $ xs
+    pure $ "{" <> contents <> newline <> indentBy i <> "}"
     where newline = "\n"
           indentBy = flip T.replicate "\t"
 

--- a/lib/Intlc/Compiler.hs
+++ b/lib/Intlc/Compiler.hs
@@ -37,7 +37,7 @@ compileTranslation l k (Translation v be _) = case be of
   TypeScriptReact -> TS.compileNamedExport JSX         l k v
 
 compileFlattened :: Dataset (Translation (ICU.Message ICU.Node)) -> Text
-compileFlattened = JSON.compileDataset . mapMsgs (fmap flatten)
+compileFlattened = JSON.compileDataset JSON.Minified . mapMsgs (fmap flatten)
 
 mapMsgs :: (ICU.Message ICU.Node -> ICU.Message ICU.Node) -> Dataset (Translation (ICU.Message ICU.Node)) -> Dataset (Translation (ICU.Message ICU.Node))
 mapMsgs f = fmap $ \x -> x { message = f x.message }

--- a/lib/Intlc/Compiler.hs
+++ b/lib/Intlc/Compiler.hs
@@ -36,8 +36,8 @@ compileTranslation l k (Translation v be _) = case be of
   TypeScript      -> TS.compileNamedExport TemplateLit l k v
   TypeScriptReact -> TS.compileNamedExport JSX         l k v
 
-compileFlattened :: Dataset (Translation (ICU.Message ICU.Node)) -> Text
-compileFlattened = JSON.compileDataset JSON.Minified . mapMsgs (fmap flatten)
+compileFlattened :: JSON.Formatting -> Dataset (Translation (ICU.Message ICU.Node)) -> Text
+compileFlattened fo = JSON.compileDataset fo . mapMsgs (fmap flatten)
 
 mapMsgs :: (ICU.Message ICU.Node -> ICU.Message ICU.Node) -> Dataset (Translation (ICU.Message ICU.Node)) -> Dataset (Translation (ICU.Message ICU.Node))
 mapMsgs f = fmap $ \x -> x { message = f x.message }

--- a/test/Intlc/CompilerSpec.hs
+++ b/test/Intlc/CompilerSpec.hs
@@ -1,13 +1,15 @@
 module Intlc.CompilerSpec (spec) where
 
-import           Intlc.Compiler    (compileDataset, compileFlattened,
-                                    expandRules, flatten)
-import           Intlc.Core        (Backend (..), Locale (Locale),
-                                    Translation (Translation))
+import qualified Data.Text                   as T
+import qualified Intlc.Backend.JSON.Compiler as JSON
+import           Intlc.Compiler              (compileDataset, compileFlattened,
+                                              expandRules, flatten)
+import           Intlc.Core                  (Backend (..), Locale (Locale),
+                                              Translation (Translation))
 import           Intlc.ICU
-import           Prelude           hiding (one)
+import           Prelude                     hiding (one)
 import           Test.Hspec
-import           Text.RawString.QQ (r)
+import           Text.RawString.QQ           (r)
 
 spec :: Spec
 spec = describe "compiler" $ do
@@ -25,16 +27,48 @@ spec = describe "compiler" $ do
       f [""] `shouldSatisfy` isLeft
 
   describe "compile flattened dataset" $ do
-    it "flattens messages and outputs JSON" $ do
-      compileFlattened (fromList
-        [ ("x", Translation (Message "xfoo") TypeScript Nothing)
-        , ("z", Translation (Message "zfoo") TypeScriptReact (Just "zbar"))
-        , ("y", Translation (Message $ mconcat ["yfoo ", String' "ybar"]) TypeScript Nothing)
-        ])
-          `shouldBe` [r|{"x":{"message":"xfoo","backend":"ts","description":null},"y":{"message":"yfoo {ybar}","backend":"ts","description":null},"z":{"message":"zfoo","backend":"tsx","description":"zbar"}}|]
+    let f = compileFlattened
+
+    describe "flattens messages and outputs JSON" $ do
+      let xs = fromList
+            [ ("x", Translation (Message "xfoo") TypeScript Nothing)
+            , ("z", Translation (Message "zfoo") TypeScriptReact (Just "zbar"))
+            , ("y", Translation (Message $ mconcat ["yfoo ", String' "ybar"]) TypeScript Nothing)
+            ]
+
+      it "minified" $ do
+        f JSON.Minified xs `shouldBe`
+          [r|{"x":{"message":"xfoo","backend":"ts","description":null},"y":{"message":"yfoo {ybar}","backend":"ts","description":null},"z":{"message":"zfoo","backend":"tsx","description":"zbar"}}|]
+
+      it "prettified" $ do
+        let toTabs = T.replace "  " "\t"
+
+        -- Ideally this'd be improved, but the current simple algo gives us
+        -- this on an empty dataset.
+        f JSON.Pretty mempty `shouldBe` [r|{
+
+}|]
+
+        f JSON.Pretty xs `shouldBe` toTabs [r|{
+  "x": {
+    "message": "xfoo",
+    "backend": "ts",
+    "description": null
+  },
+  "y": {
+    "message": "yfoo {ybar}",
+    "backend": "ts",
+    "description": null
+  },
+  "z": {
+    "message": "zfoo",
+    "backend": "tsx",
+    "description": "zbar"
+  }
+}|]
 
     it "escapes double quotes in JSON" $ do
-      compileFlattened (fromList [("x\"y", Translation (Message "\"z\"") TypeScript Nothing)])
+      f JSON.Minified (fromList [("x\"y", Translation (Message "\"z\"") TypeScript Nothing)])
         `shouldBe` [r|{"x\"y":{"message":"\"z\"","backend":"ts","description":null}}|]
 
   describe "flatten message" $ do

--- a/test/Intlc/CompilerSpec.hs
+++ b/test/Intlc/CompilerSpec.hs
@@ -43,10 +43,7 @@ spec = describe "compiler" $ do
       it "prettified" $ do
         let toTabs = T.replace "  " "\t"
 
-        -- Ideally this'd be improved, but the current simple algo gives us
-        -- this on an empty dataset.
         f JSON.Pretty mempty `shouldBe` [r|{
-
 }|]
 
         f JSON.Pretty xs `shouldBe` toTabs [r|{


### PR DESCRIPTION
This PR adds a `--minify` flag anywhere we're outputting JSON, and absent that - by default - outputs prettified JSON.

The formatting logic is mostly copied from the prettify module (which prettifies ICU for `intlc prettify`). As there prettified output uses tabs for indentation.

Example:

```console
$ cat x.json
{
  "x": { "message": "Hello {name}" },
  "y": { "message": "Today is a {day, select, Friday {glorious} other {fine}} day." },
}

$ intlc flatten x.json
{
	"x": {
		"message": "Hello {name}",
		"backend": "ts",
		"description": null
	},
	"y": {
		"message": "{day, select, Friday {Today is a glorious day.} other {Today is a fine day.}}",
		"backend": "ts",
		"description": null
	}
}

$ intlc flatten x.json --minify
{"x":{"message":"Hello {name}","backend":"ts","description":null},"y":{"message":"{day, select, Friday {Today is a glorious day.} other {Today is a fine day.}}","backend":"ts","description":null}}

```

Closes #47.