### PR TITLE
Add --indent option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to semantic versioning.
 
 ## 0.8.0 (_Unreleased_)
 
-Added `--indent` option to the flatten command. This enables explicit configuration of formatting indentation either as tabs or as a number of spaces. The option is ignored in the presence of `--minify`.
+Added `--indent` option to the flatten and prettify commands. This enables explicit configuration of formatting indentation either as tabs or as a number of spaces. The option is ignored in the presence of `--minify` where applicable.
 
 Shifted everything from the "internal" binary into the main binary behind hidden flags.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to semantic versioning.
 
 ## 0.8.0 (_Unreleased_)
 
+Added `--indent` option to the flatten command. This enables explicit configuration of formatting indentation either as tabs or as a number of spaces. The option is ignored in the presence of `--minify`.
+
 Shifted everything from the "internal" binary into the main binary behind hidden flags.
 
 Improved CI binary naming, clarifying in particular which architecture they're built against.

--- a/cli/CLI.hs
+++ b/cli/CLI.hs
@@ -3,7 +3,7 @@ module CLI (Opts (..), getOpts, ICUModifiers (..)) where
 import qualified Intlc.Backend.JSON.Compiler as JSON
 import           Intlc.Core                  (Locale (..))
 import           Intlc.Linter                (LintRuleset (..))
-import           Intlc.Printer               (IndentStyle (..))
+import           Intlc.Printer               (IndentStyle (..), def)
 import           Options.Applicative
 import           Prelude
 
@@ -56,7 +56,7 @@ prettify :: Parser Opts
 prettify = Prettify <$> msgp <*> indentp
 
 indentp :: Parser IndentStyle
-indentp = option (eitherReader parseIndentation) (value Tabs <> long "indent" <> metavar "NAT")
+indentp = option (eitherReader parseIndentation) (value def <> long "indent" <> metavar "NAT")
   where parseIndentation x
           | x == "tab" || x == "tabs" = Right Tabs
           | otherwise = maybe (Left e) (Right . Spaces) (readMaybe x)

--- a/cli/CLI.hs
+++ b/cli/CLI.hs
@@ -38,11 +38,6 @@ flatten = Flatten <$> pathp <*> jsonfmtp <*> expandp
           where f False x = JSON.Pretty x
                 f True  _ = JSON.Minified
         minifyp = flag False True (long "minify")
-        indentp = option (eitherReader parseIndentation) (value Tabs <> long "indent" <> metavar "NAT")
-        parseIndentation x
-          | x == "tab" || x == "tabs" = Right Tabs
-          | otherwise = maybe (Left e) (Right . Spaces) (readMaybe x)
-          where e = "Requires a natural number of spaces or tabs."
 
 lint :: Parser Opts
 lint = Lint <$> pathp <*> internalp
@@ -59,3 +54,10 @@ localep = Locale <$> strOption (short 'l' <> long "locale")
 
 prettify :: Parser Opts
 prettify = Prettify <$> msgp
+
+indentp :: Parser IndentStyle
+indentp = option (eitherReader parseIndentation) (value Tabs <> long "indent" <> metavar "NAT")
+  where parseIndentation x
+          | x == "tab" || x == "tabs" = Right Tabs
+          | otherwise = maybe (Left e) (Right . Spaces) (readMaybe x)
+          where e = "Requires a natural number of spaces or tabs."

--- a/cli/CLI.hs
+++ b/cli/CLI.hs
@@ -11,7 +11,7 @@ data Opts
   = Compile FilePath Locale
   | Flatten FilePath JSON.Formatting [ICUModifiers]
   | Lint    FilePath LintRuleset
-  | Prettify Text
+  | Prettify Text IndentStyle
 
 data ICUModifiers
   = ExpandPlurals
@@ -53,7 +53,7 @@ localep :: Parser Locale
 localep = Locale <$> strOption (short 'l' <> long "locale")
 
 prettify :: Parser Opts
-prettify = Prettify <$> msgp
+prettify = Prettify <$> msgp <*> indentp
 
 indentp :: Parser IndentStyle
 indentp = option (eitherReader parseIndentation) (value Tabs <> long "indent" <> metavar "NAT")

--- a/cli/Main.hs
+++ b/cli/Main.hs
@@ -10,6 +10,7 @@ import           Intlc.Linter
 import           Intlc.Parser       (parseDataset, parseMessage, printErr)
 import           Intlc.Parser.Error (ParseFailure)
 import           Intlc.Prettify     (prettify)
+import           Intlc.Printer      (IndentStyle)
 import           Prelude
 
 main :: IO ()
@@ -26,7 +27,7 @@ main = getOpts >>= \case
           mods = ms <&> \case
             ExpandPlurals -> expandPlurals
   Lint    path lr    -> lint lr path
-  Prettify msg       -> tryPrettify msg
+  Prettify msg fo    -> tryPrettify fo msg
 
 compile :: MonadIO m => Locale -> Dataset (Translation (Message Node)) -> m ()
 compile loc = compileDataset loc >>> \case
@@ -39,8 +40,8 @@ lint lr path = do
   dataset <- parserDie $ parseDataset path raw
   whenJust (lintDataset lr path raw dataset) $ die . T.unpack
 
-tryPrettify :: MonadIO m => Text -> m ()
-tryPrettify = either (die . printErr) (putTextLn . prettify . fmap sansAnn) . parseMessage "input"
+tryPrettify :: MonadIO m => IndentStyle -> Text -> m ()
+tryPrettify fmt = either (die . printErr) (putTextLn . prettify fmt . fmap sansAnn) . parseMessage "input"
 
 tryGetParsedAtSansAnn :: MonadIO m => FilePath -> m (Dataset (Translation (Message Node)))
 tryGetParsedAtSansAnn = parserDie . fmap datasetSansAnn <=< getParsedAt

--- a/intlc.cabal
+++ b/intlc.cabal
@@ -65,6 +65,7 @@ library
     Intlc.Parser.JSON
     Intlc.Parser.ICU
     Intlc.Prettify
+    Intlc.Printer
     Utils
 
 test-suite test-intlc

--- a/lib/Intlc/Prettify.hs
+++ b/lib/Intlc/Prettify.hs
@@ -2,7 +2,8 @@ module Intlc.Prettify (prettify) where
 
 import           Intlc.Backend.ICU.Compiler (Formatting (..), compileMsg)
 import qualified Intlc.ICU                  as ICU
+import           Intlc.Printer              (IndentStyle)
 import           Prelude
 
-prettify :: ICU.Message ICU.Node -> Text
-prettify = compileMsg MultiLine
+prettify :: IndentStyle -> ICU.Message ICU.Node -> Text
+prettify = compileMsg . MultiLine

--- a/lib/Intlc/Printer.hs
+++ b/lib/Intlc/Printer.hs
@@ -7,6 +7,10 @@ data IndentStyle
   = Tabs
   | Spaces Nat
 
+-- The default indent style unless otherwise specified by the user.
+def :: IndentStyle
+def = Tabs
+
 indenter :: IndentStyle -> Nat -> Text
 indenter Tabs       = flip T.replicate "\t" . fromEnum
 indenter (Spaces n) = flip T.replicate " " . fromEnum . (* n)

--- a/lib/Intlc/Printer.hs
+++ b/lib/Intlc/Printer.hs
@@ -1,0 +1,12 @@
+module Intlc.Printer where
+
+import qualified Data.Text as T
+import           Prelude
+
+data IndentStyle
+  = Tabs
+  | Spaces Nat
+
+indenter :: IndentStyle -> Nat -> Text
+indenter Tabs       = flip T.replicate "\t" . fromEnum
+indenter (Spaces n) = flip T.replicate " " . fromEnum . (* n)

--- a/test/Intlc/CompilerSpec.hs
+++ b/test/Intlc/CompilerSpec.hs
@@ -7,6 +7,7 @@ import           Intlc.Compiler              (compileDataset, compileToJSON,
 import           Intlc.Core                  (Backend (..), Locale (Locale),
                                               Translation (Translation))
 import           Intlc.ICU
+import           Intlc.Printer               (IndentStyle (..))
 import           Prelude                     hiding (one)
 import           Test.Hspec
 import           Text.RawString.QQ           (r)
@@ -42,11 +43,8 @@ spec = describe "compiler" $ do
 
       it "prettified" $ do
         let toTabs = T.replace "  " "\t"
-
-        f JSON.Pretty mempty `shouldBe` [r|{
-}|]
-
-        f JSON.Pretty xs `shouldBe` toTabs [r|{
+        let toFourSpaces = T.replace "  " "    "
+        let xsOut = [r|{
   "x": {
     "message": "xfoo",
     "backend": "ts",
@@ -63,6 +61,13 @@ spec = describe "compiler" $ do
     "description": "zbar"
   }
 }|]
+
+        f (JSON.Pretty Tabs) mempty `shouldBe` [r|{
+}|]
+
+        f (JSON.Pretty Tabs) xs `shouldBe` toTabs xsOut
+        f (JSON.Pretty (Spaces 2)) xs `shouldBe` xsOut
+        f (JSON.Pretty (Spaces 4)) xs `shouldBe` toFourSpaces xsOut
 
     it "escapes double quotes in JSON" $ do
       f JSON.Minified (fromList [("x\"y", Translation (Message "\"z\"") TypeScript Nothing)])

--- a/test/Intlc/PrettifySpec.hs
+++ b/test/Intlc/PrettifySpec.hs
@@ -3,12 +3,13 @@ module Intlc.PrettifySpec where
 import qualified Data.Text      as T
 import           Intlc.ICU
 import           Intlc.Prettify (prettify)
+import           Intlc.Printer  (IndentStyle (..))
 import           Prelude
 import           Test.Hspec
 
 spec :: Spec
 spec = describe "prettify" $ do
-  let f = prettify . Message
+  let f x = prettify x . Message
 
   it "compiles to ICU with multiline formatting" $ do
     let ast = mconcat
@@ -54,4 +55,4 @@ spec = describe "prettify" $ do
           , "}"
           ]
     -- Some trailing spaces are expected with the current implementation.
-    f ast `shouldBe` toTabs expected
+    f Tabs ast `shouldBe` toTabs expected


### PR DESCRIPTION
Closes #194. Once this is merged I'll release 0.8.

```console
$ cat x.json
{
  "x": { "message": "Hello {name}" },
  "y": { "message": "Today is a {day, select, Friday {glorious} other {fine}} day." },
}
$ # Default behaviour is unchanged, we still print tabs.
$ intlc flatten x.json
{
	"x": {
		"message": "Hello {name}",
		"backend": "ts",
		"description": null
	},
	"y": {
		"message": "{day, select, Friday {Today is a glorious day.} other {Today is a fine day.}}",
		"backend": "ts",
		"description": null
	}
}
$ # Minification is likewise unchanged, even in the presence of --indent.
$ intlc flatten --minify --indent 4 x.json
{"x":{"message":"Hello {name}","backend":"ts","description":null},"y":{"message":"{day, select, Friday {Today is a glorious day.} other {Today is a fine day.}}","backend":"ts","description":null}}
$ # The new --indent option accepts "tab", "tabs", or a natural number describing the number of spaces with which to indent. "tab" and "tabs" are equivalent to the default behaviour.
$ intlc flatten --indent tabs x.json
{
	"x": {
		"message": "Hello {name}",
		"backend": "ts",
		"description": null
	},
	"y": {
		"message": "{day, select, Friday {Today is a glorious day.} other {Today is a fine day.}}",
		"backend": "ts",
		"description": null
	}
}
$ # But we can now indent with spaces!
$ intlc flatten --indent 2 x.json

{
  "x": {
    "message": "Hello {name}",
    "backend": "ts",
    "description": null
  },
  "y": {
    "message": "{day, select, Friday {Today is a glorious day.} other {Today is a fine day.}}",
    "backend": "ts",
    "description": null
  }
}
$ # Even if you like really extreme indentation...
$ intlc flatten --indent 12 x.json
{
            "x": {
                        "message": "Hello {name}",
                        "backend": "ts",
                        "description": null
            },
            "y": {
                        "message": "{day, select, Friday {Today is a glorious day.} other {Today is a fine day.}}",
                        "backend": "ts",
                        "description": null
            }
}

```