### PR TITLE
Add --version option

### DIFF
--- a/cli/CLI.hs
+++ b/cli/CLI.hs
@@ -1,5 +1,8 @@
+{-# LANGUAGE TemplateHaskell #-}
+
 module CLI (Opts (..), getOpts, ICUModifiers (..)) where
 
+import           GitHash                     (giTag, tGitInfoCwd)
 import qualified Intlc.Backend.JSON.Compiler as JSON
 import           Intlc.Core                  (Locale (..))
 import           Intlc.Linter                (LintRuleset (..))
@@ -16,8 +19,13 @@ data ICUModifiers
   = ExpandPlurals
 
 getOpts :: IO Opts
-getOpts = execParser (info (opts <**> helper) (progDesc h))
+getOpts = execParser (info (opts <**> helper <**> version) (progDesc h))
   where h = "Compile ICU messages into code."
+
+version :: Parser (a -> a)
+version = infoOption (giTag gi) (long "version" <> help msg)
+  where msg = "Print version information"
+        gi = $$tGitInfoCwd
 
 opts :: Parser Opts
 opts = subparser . mconcat $

--- a/intlc.cabal
+++ b/intlc.cabal
@@ -38,6 +38,7 @@ executable intlc
   main-is:                 Main.hs
   build-depends:
       intlc
+    , githash              ^>=0.1
     , optparse-applicative ^>=0.16
   other-modules:
     CLI


### PR DESCRIPTION
Closes #98.

Follows the [CLIG](https://clig.dev/#arguments-and-flags) idiom/suggestion of `--version`.

Uses Git to produce the output so it can't fall out of date. Ideally it'd conditionally append "-dirty" as well, but that's not currently supported by the library and my own attempt was flaky.

```console
$ git switch version-opt
$ cabal run -- intlc --version
v0.7.0-12-g8624452
$ git tag v0.8.0
$ cabal clean # Cabal doesn't know we need to rebuild. Naturally won't be an issue in CI.
$ cabal run -- intlc --version
v0.8.0
$ touch foo && git add foo && git commit
$ cabal clean
$ cabal run -- intlc --version
v0.8.0-1-g06fd894
```