### PR TITLE
Flatten callback nodes

### DIFF
--- a/test/Intlc/CompilerSpec.hs
+++ b/test/Intlc/CompilerSpec.hs
@@ -133,6 +133,61 @@ spec = describe "compiler" $ do
 
       flatten x `shouldBe` y
 
+    it "flattens callbacks" $ do
+      let x = mconcat
+            [ "Today is "
+            , Callback' "bold" (mconcat
+                [ ">"
+                , SelectNamedWild'
+                    "day"
+                    (fromList
+                      [ ("Saturday", "the weekend")
+                      , ("Sunday", "the weekend, barely")
+                      ]
+                    )
+                    "a weekday"
+                , "<"
+                ]
+              )
+            , "."
+            ]
+
+      let y =
+            SelectNamedWild'
+              "day"
+              (fromList
+                [ ("Saturday", mconcat
+                    [ "Today is "
+                    , Callback' "bold" (mconcat
+                        [ ">the weekend<"
+                        ]
+                      )
+                    , "."
+                    ]
+                )
+                , ("Sunday", mconcat
+                    [ "Today is "
+                    , Callback' "bold" (mconcat
+                        [ ">the weekend, barely<"
+                        ]
+                      )
+                    , "."
+                    ]
+                )
+                ]
+              )
+              (mconcat
+                [ "Today is "
+                , Callback' "bold" (mconcat
+                    [ ">a weekday<"
+                    ]
+                  )
+                , "."
+                ]
+              )
+
+      flatten x `shouldBe` y
+
   describe "expanding rules" $ do
     let f = expandRules
 


### PR DESCRIPTION
Should fix #199

I took the aggressive approach described in #199.

I ran it on our set of translation files and it didn't change anything except for two files that were correctly fixed :)

I left a comment to explain the Callback branch as a lot happen in a single line.

There might be some issues with formatting and general Haskell conventions.