### PR TITLE
GHC 9.4

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -12,14 +12,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v18
+      - uses: cachix/install-nix-action@v22
       - run: nix flake check
   build:
     name: Build
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v18
+      - uses: cachix/install-nix-action@v22
       - run: nix develop -c cabal update
       - run: nix develop -c cabal freeze
       - uses: actions/cache@v3
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v18
+      - uses: cachix/install-nix-action@v22
       - run: nix develop -c cabal update
       - run: nix develop -c cabal freeze
       - uses: actions/cache@v3
@@ -45,14 +45,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v18
+      - uses: cachix/install-nix-action@v22
       - run: nix develop -c hlint lib cli test
   fmt:
     name: Formatting
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v18
+      - uses: cachix/install-nix-action@v22
       # stylish-haskell doesn't have a check/dry run option, so we'll run it
       # against files in place and test if there are any diffs with Git.
       - run: |
@@ -66,7 +66,7 @@ jobs:
         working-directory: .golden/ts/
     steps:
       - uses: actions/checkout@v3
-      - uses: cachix/install-nix-action@v18
+      - uses: cachix/install-nix-action@v22
       - uses: actions/cache@v3
         with:
           path: ~/.cache/yarn/v6

--- a/README.md
+++ b/README.md
@@ -120,4 +120,4 @@ The description is optional and ignored by intlc. It can be used documentatively
 
 Check out `ARCHITECTURE.md`.
 
-Currently building against GHC 9.2.4. A Nix flake is included with all necessary dependencies. Contributors on Apple silicon will need to source GHC and HLS externally, for example via ghcup.
+Currently building against GHC 9.4.6. A Nix flake is included with all necessary dependencies.

--- a/flake.lock
+++ b/flake.lock
@@ -1,12 +1,15 @@
 {
   "nodes": {
     "flake-utils": {
+      "inputs": {
+        "systems": "systems"
+      },
       "locked": {
-        "lastModified": 1659877975,
-        "narHash": "sha256-zllb8aq3YO3h8B/U0/J1WBgAL8EX5yWf5pMj3G0NAmc=",
+        "lastModified": 1694529238,
+        "narHash": "sha256-zsNZZGTGnMOf9YpHKJqMSsa0dXbfmxeoJ7xHlrt+xmY=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "c0e246b9b83f637f4681389ecabcb2681b4f3af0",
+        "rev": "ff7b65b44d01cf9ba6a71320833626af21126384",
         "type": "github"
       },
       "original": {
@@ -17,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1665613119,
-        "narHash": "sha256-VTutbv5YKeBGWou6ladtgfx11h6et+Wlkdyh4jPJ3p0=",
-        "owner": "NixOS",
+        "lastModified": 1694593561,
+        "narHash": "sha256-WSaIQZ5s9N9bDFkEMTw6P9eaZ9bv39ZhsiW12GtTNM0=",
+        "owner": "nixos",
         "repo": "nixpkgs",
-        "rev": "e06bd4b64bbfda91d74f13cb5eca89485d47528f",
+        "rev": "1697b7d480449b01111e352021f46e5879e47643",
         "type": "github"
       },
       "original": {
@@ -35,6 +38,21 @@
       "inputs": {
         "flake-utils": "flake-utils",
         "nixpkgs": "nixpkgs"
+      }
+    },
+    "systems": {
+      "locked": {
+        "lastModified": 1681028828,
+        "narHash": "sha256-Vy1rq5AaRuLzOxct8nz4T6wlgyUR7zLU309k9mBC768=",
+        "owner": "nix-systems",
+        "repo": "default",
+        "rev": "da67096a3b9bf56a91d16901293e51ba5b49a27e",
+        "type": "github"
+      },
+      "original": {
+        "owner": "nix-systems",
+        "repo": "default",
+        "type": "github"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -58,8 +58,6 @@
       in {
         devShells.default = pkgs.mkShell {
           nativeBuildInputs = with pkgs; [
-            git
-
             cabal-install
             hlint
             haskPkgs.hspec-golden

--- a/flake.nix
+++ b/flake.nix
@@ -1,36 +1,3 @@
-# There are two major considerations when picking a version of GHC for this
-# project.
-#
-# Firstly, we'd like the version we choose to have tooling available in Nix's
-# binary cache, without contributors having to mess around with additional
-# caches. This limits us to the "default" version of GHC in nixpkgs.
-#
-# With this in mind, we could simply use the `ghc` and `haskellPackages`
-# package and package set, however the following has been written with
-# flexibility in mind. Note that using `haskellPackages` implicitly brings the
-# default version of GHC into scope as it's merely an alias for the default
-# package set [1].
-#
-# Secondly, HLS is currently marked as broken on aarch64-darwin [2], which
-# impacts Apple silicon contributors. With this in mind we're also keen to
-# ensure that our chosen version of GHC is supported by HLS as distributed via
-# ghcup.
-#
-# This means we're effectively stuck with whichever version of GHC is both the
-# default for nixpkgs at some point in time - in the past is okay, as nixpkgs
-# is pinned and the cache is long-lived - and which has the requisite support
-# in ghcup as well. At time of writing that version is 9.4.6.
-#
-# Further complicating matters, GHC and HLS need to be sourced from the same
-# place to ensure that HLS was compiled against that same version of GHC, lest
-# we see "ABIs don't match" errors. Therefore aarch64-darwin contributors must
-# not only source HLS externally but also GHC.
-#
-# In short, don't upgrade GHC until it's the default in nixpkgs, and available
-# in ghcup and supported by HLS there as well.
-#
-# [1]: https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/haskell.section.md#available-packages-haskell-available-packages
-# [2]: https://github.com/NixOS/nixpkgs/blob/a410420844fe1ad6415cf9586308fe7538cc7584/pkgs/development/compilers/llvm/7/compiler-rt/default.nix#L108
 {
   inputs = {
     nixpkgs.url = "github:nixos/nixpkgs/nixpkgs-unstable";
@@ -41,19 +8,18 @@
     flake-utils.lib.eachDefaultSystem (system:
       let pkgs = nixpkgs.legacyPackages.${system};
 
+          # We'll stick with the "default" version of GHC in nixpkgs to benefit
+          # from the binary cache:
+          #   https://github.com/NixOS/nixpkgs/blob/master/doc/languages-frameworks/haskell.section.md#available-packages-haskell-available-packages
           ghcVer = "ghc946";
-          haskPkgs = pkgs.haskell.packages."${ghcVer}";
 
-          hask = if system == flake-utils.lib.system.aarch64-darwin
-            then [ ]
-            else [
-              pkgs.haskell.compiler."${ghcVer}"
-              haskPkgs.haskell-language-server
-            ];
+          haskPkgs = pkgs.haskell.packages."${ghcVer}";
       in {
         devShells.default = pkgs.mkShell {
           nativeBuildInputs = with pkgs; [
             cabal-install
+            haskell.compiler."${ghcVer}"
+            haskPkgs.haskell-language-server
             hlint
             haskPkgs.hspec-golden
             stylish-haskell
@@ -61,7 +27,7 @@
             # For typechecking golden output
             nodejs
             yarn
-          ] ++ hask;
+          ];
         };
       });
 }

--- a/flake.nix
+++ b/flake.nix
@@ -45,16 +45,15 @@
     flake-utils.lib.eachDefaultSystem (system:
       let pkgs = nixpkgs.legacyPackages.${system};
 
-          ghcVer = "924";
+          ghcVer = "ghc924";
+          haskPkgs = pkgs.haskell.packages."${ghcVer}";
 
           hask = if system == flake-utils.lib.system.aarch64-darwin
             then [ ]
-            else with pkgs; [
-              haskell.compiler."ghc${ghcVer}"
-              (haskell-language-server.override { supportedGhcVersions = [ ghcVer ];})
+            else [
+              pkgs.haskell.compiler."${ghcVer}"
+              haskPkgs.haskell-language-server
             ];
-
-          haskPkgs = pkgs.haskell.packages."ghc${ghcVer}";
       in {
         devShells.default = pkgs.mkShell {
           nativeBuildInputs = with pkgs; [

--- a/flake.nix
+++ b/flake.nix
@@ -19,16 +19,12 @@
 # This means we're effectively stuck with whichever version of GHC is both the
 # default for nixpkgs at some point in time - in the past is okay, as nixpkgs
 # is pinned and the cache is long-lived - and which has the requisite support
-# in ghcup as well. At time of writing that version is 9.2.4.
+# in ghcup as well. At time of writing that version is 9.4.6.
 #
 # Further complicating matters, GHC and HLS need to be sourced from the same
 # place to ensure that HLS was compiled against that same version of GHC, lest
 # we see "ABIs don't match" errors. Therefore aarch64-darwin contributors must
 # not only source HLS externally but also GHC.
-#
-# But that's not all! A subset of Apple silicon contributors have reported being
-# unable to run compiled 9.2.4 code. 9.2.5 fixes it. These users are encouraged
-# to use 9.2.5 for the timebeing irrespective of the configuration here.
 #
 # In short, don't upgrade GHC until it's the default in nixpkgs, and available
 # in ghcup and supported by HLS there as well.
@@ -45,7 +41,7 @@
     flake-utils.lib.eachDefaultSystem (system:
       let pkgs = nixpkgs.legacyPackages.${system};
 
-          ghcVer = "ghc924";
+          ghcVer = "ghc946";
           haskPkgs = pkgs.haskell.packages."${ghcVer}";
 
           hask = if system == flake-utils.lib.system.aarch64-darwin

--- a/intlc.cabal
+++ b/intlc.cabal
@@ -14,7 +14,7 @@ common common
   ghc-options:
     -Wall
   build-depends:
-      base                 ^>=4.16
+      base                 ^>=4.17
     , bytestring           ^>=0.11
     , comonad              ^>=5.0
     , containers           ^>=0.6
@@ -24,8 +24,8 @@ common common
     , free                 ^>=5.1
     , mtl                  ^>=2.2
     , recursion-schemes    ^>=5.2
-    , relude               ^>=1.1
-    , text                 ^>=1.2
+    , relude               ^>=1.2
+    , text                 ^>=2.0
     , validation           ^>=1.1
   mixins:
       base hiding (Prelude)
@@ -48,7 +48,7 @@ library
   hs-source-dirs:          lib/
   build-depends:
       parser-combinators   ^>=1.2
-    , megaparsec           ^>=9.0
+    , megaparsec           ^>=9.5
   exposed-modules:
     Intlc.Compiler
     Intlc.Backend.JavaScript.Language
@@ -79,10 +79,10 @@ test-suite test-intlc
   build-depends:
       intlc
     , filepath              ^>=1.4
-    , hspec                 ^>=2.7
+    , hspec                 ^>=2.11
     , hspec-golden          ^>=0.2
     , hspec-megaparsec      ^>=2.2
-    , megaparsec            ^>=9.0
+    , megaparsec            ^>=9.5
     , raw-strings-qq        ^>=1.1
   build-tool-depends:
       hspec-discover:hspec-discover


### PR DESCRIPTION
Edit: As below this PR not only bumps GHC but also resolves HLS for Apple Silicon users, meaning all contributors can now source all dependencies straight from Nix! :tada: 

Notes for reviewers (given divergent OS/arch):

1. Ensure that none of the dependencies need to build. They should download and just work via the binary cache.
2. Double check that HLS still doesn't work on macOS AArch64 \*.
3. ~~Assuming HLS doesn't work, ensure that you can source GHC 9.4.6 and HLS from ghcup. From a quick look I think it should be available.~~ HLS can now be sourced from Nix for all contributors! :tada: 

\* Try this patch and see if it yells at you (it'd fail on master, and GitHub has no ARM runners for us to `nix flake check` against):

```diff
diff --git a/flake.nix b/flake.nix
index 9f53c66..18d0f4d 100644
--- a/flake.nix
+++ b/flake.nix
@@ -44,9 +44,7 @@
           ghcVer = "ghc946";
           haskPkgs = pkgs.haskell.packages."${ghcVer}";
 
-          hask = if system == flake-utils.lib.system.aarch64-darwin
-            then [ ]
-            else [
+          hask = [
               pkgs.haskell.compiler."${ghcVer}"
               haskPkgs.haskell-language-server
             ];

```

- [x] Note to self: Update README accordingly before merging.