### PR TITLE
Better CI caching

### DIFF
--- a/.github/actions/cabal-cache/action.yml
+++ b/.github/actions/cabal-cache/action.yml
@@ -1,4 +1,4 @@
-name: Cabal dependency cache
+name: Cabal dependency and incremental build caches
 runs:
   using: composite
   steps:
@@ -9,3 +9,10 @@ runs:
         key: cabal-${{ runner.os }}-${{ hashFiles('cabal.project.freeze') }}
         restore-keys: |
           cabal-${{ runner.os }}
+    - name: Cache incremental build
+      uses: actions/cache@v3
+      with:
+        path: ./dist-newstyle/
+        key: dist-${{ runner.os }}-${{ github.sha }}
+        restore-keys: |
+          dist-${{ runner.os }}

--- a/.github/actions/cabal-cache/action.yml
+++ b/.github/actions/cabal-cache/action.yml
@@ -5,7 +5,7 @@ runs:
     - name: Cache dependencies
       uses: actions/cache@v3
       with:
-        path: ~/.cabal/store
+        path: ~/.local/state/cabal/store/
         key: cabal-${{ runner.os }}-${{ hashFiles('cabal.project.freeze') }}
         restore-keys: |
           cabal-${{ runner.os }}

--- a/.github/actions/cabal-cache/action.yml
+++ b/.github/actions/cabal-cache/action.yml
@@ -1,0 +1,11 @@
+name: Cabal dependency cache
+runs:
+  using: composite
+  steps:
+    - name: Cache dependencies
+      uses: actions/cache@v3
+      with:
+        path: ~/.cabal/store
+        key: cabal-${{ runner.os }}-${{ hashFiles('cabal.project.freeze') }}
+        restore-keys: |
+          cabal-${{ runner.os }}

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -26,6 +26,8 @@ jobs:
         with:
           path: ~/.cabal/store
           key: cabal-${{ runner.os }}-${{ hashFiles('cabal.project.freeze') }}
+          restore-keys: |
+            cabal-${{ runner.os }}
       - run: nix develop -c cabal build
   test:
     name: Test
@@ -39,6 +41,8 @@ jobs:
         with:
           path: ~/.cabal/store
           key: cabal-${{ runner.os }}-${{ hashFiles('cabal.project.freeze') }}
+          restore-keys: |
+            cabal-${{ runner.os }}
       - run: nix develop -c cabal test
   lint:
     name: Lint
@@ -71,5 +75,7 @@ jobs:
         with:
           path: ~/.cache/yarn/v6
           key: yarn-${{ runner.os }}-${{ hashFiles('.golden/ts/yarn.lock') }}
+          restore-keys: |
+            yarn-${{ runner.os }}
       - run: nix develop -c yarn install --frozen-lockfile
       - run: nix develop -c yarn typecheck

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -67,5 +67,5 @@ jobs:
           key: yarn-${{ runner.os }}-${{ hashFiles('.golden/ts/yarn.lock') }}
           restore-keys: |
             yarn-${{ runner.os }}
-      - run: nix develop -c yarn install --frozen-lockfile
-      - run: nix develop -c yarn typecheck
+      - run: nix develop .#golden -c yarn install --frozen-lockfile
+      - run: nix develop .#golden -c yarn typecheck

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -22,12 +22,7 @@ jobs:
       - uses: cachix/install-nix-action@v22
       - run: nix develop -c cabal update
       - run: nix develop -c cabal freeze
-      - uses: actions/cache@v3
-        with:
-          path: ~/.cabal/store
-          key: cabal-${{ runner.os }}-${{ hashFiles('cabal.project.freeze') }}
-          restore-keys: |
-            cabal-${{ runner.os }}
+      - uses: ./.github/actions/cabal-cache
       - run: nix develop -c cabal build
   test:
     name: Test
@@ -37,12 +32,7 @@ jobs:
       - uses: cachix/install-nix-action@v22
       - run: nix develop -c cabal update
       - run: nix develop -c cabal freeze
-      - uses: actions/cache@v3
-        with:
-          path: ~/.cabal/store
-          key: cabal-${{ runner.os }}-${{ hashFiles('cabal.project.freeze') }}
-          restore-keys: |
-            cabal-${{ runner.os }}
+      - uses: ./.github/actions/cabal-cache
       - run: nix develop -c cabal test
   lint:
     name: Lint

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -29,6 +29,8 @@ jobs:
         with:
           path: ~/.cabal/store
           key: cabal-${{ runner.os }}-${{ hashFiles('cabal.project.freeze') }}
+          restore-keys: |
+            cabal-${{ runner.os }}
       - name: Build
         run: |
           # Unlike `cabal build`, `cabal install` appears to build in a

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,12 +25,7 @@ jobs:
         with:
           ghc-version: 9.4.6
       - run: cabal freeze
-      - uses: actions/cache@v3
-        with:
-          path: ~/.cabal/store
-          key: cabal-${{ runner.os }}-${{ hashFiles('cabal.project.freeze') }}
-          restore-keys: |
-            cabal-${{ runner.os }}
+      - uses: ./.github/actions/cabal-cache
       - name: Build
         run: |
           # Unlike `cabal build`, `cabal install` appears to build in a

--- a/flake.nix
+++ b/flake.nix
@@ -15,19 +15,24 @@
 
           haskPkgs = pkgs.haskell.packages."${ghcVer}";
       in {
-        devShells.default = pkgs.mkShell {
-          nativeBuildInputs = with pkgs; [
-            cabal-install
-            haskell.compiler."${ghcVer}"
-            haskPkgs.haskell-language-server
-            hlint
-            haskPkgs.hspec-golden
-            stylish-haskell
+        devShells = {
+          default = pkgs.mkShell {
+            nativeBuildInputs = with pkgs; [
+              cabal-install
+              haskell.compiler."${ghcVer}"
+              haskPkgs.haskell-language-server
+              hlint
+              haskPkgs.hspec-golden
+              stylish-haskell
+            ];
+          };
 
-            # For typechecking golden output
-            nodejs
-            yarn
-          ];
+          golden = pkgs.mkShell {
+            nativeBuildInputs = with pkgs; [
+              nodejs
+              yarn
+            ];
+          };
         };
       });
 }


### PR DESCRIPTION
This PR fixes the Cabal store cache, adds cache restore keys, splits TypeScript dependencies into their own Nix shell, and adds caching of incremental build artifacts.

Building is reduced from ~5 mins to ~1 min 30s. A CI run with changed code and dependencies should be expected to run somewhere between these two numbers, utilising partial caches. The TypeScript typechecking job is also reduced from ~60s to ~20s