### PR TITLE
Add write permission to publish workflow

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,8 @@ jobs:
             { name: "macos", runner: "macos-latest" },
           ]
     runs-on: ${{ matrix.os.runner }}
+    permissions: 
+      contents: write
     steps:
       - uses: actions/checkout@v3
       # Using Nix causes dynamic linking issues on macOS. It's easier to


### PR DESCRIPTION
Ref: https://github.com/softprops/action-gh-release/issues/400

It looks like this is required now due to a change in github's defaults https://github.blog/changelog/2023-02-02-github-actions-updating-the-default-github_token-permissions-to-read-only/

Here's a failed job described in the issue: https://github.com/unsplash/intlc/actions/runs/8800916562/job/24153469892