### PR TITLE
Publish/build macos-aarch64 in CI

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,8 +12,9 @@ jobs:
       matrix:
         os:
           [
-            { name: "linux", runner: "ubuntu-latest" },
-            { name: "macos", runner: "macos-latest" },
+            { name: "linux-x86_64", runner: "ubuntu-latest" },
+            { name: "macos-x86_64", runner: "macos-latest" },
+            { name: "macos-aarch64", runner: "macos-latest-xlarge" },
           ]
     runs-on: ${{ matrix.os.runner }}
     permissions: 
@@ -35,9 +36,9 @@ jobs:
           # can't access Git at compile time. Related:
           #   https://github.com/snoyberg/githash/issues/9
           cabal build
-          mv $(find ./dist-newstyle/ -name intlc -type f) dist-newstyle/intlc-${{ github.ref_name }}-${{ matrix.os.name }}-x86_64
+          mv $(find ./dist-newstyle/ -name intlc -type f) dist-newstyle/intlc-${{ github.ref_name }}-${{ matrix.os.name }}
       - name: Release
         uses: softprops/action-gh-release@v1
         with:
           files: |
-            dist-newstyle/intlc-${{ github.ref_name }}-${{ matrix.os.name }}-x86_64
+            dist-newstyle/intlc-${{ github.ref_name }}-${{ matrix.os.name }}


### PR DESCRIPTION
This _should_ work but being a "larger" runner it'll incur a small cost. Worth it to avoid wasted developer time.

Closes #188 as there's currently no demand for other OS/arch pairs.

Once merged I'll release 0.8.3 to test it. If it doesn't work I'll mess with master until it does, so this PR is mainly for visibility. 😛 